### PR TITLE
Feature/fix delete button background color on tap

### DIFF
--- a/GameDex/Common/Cells/PrimaryButtonCell.swift
+++ b/GameDex/Common/Cells/PrimaryButtonCell.swift
@@ -54,7 +54,10 @@ final class PrimaryButtonCell: UICollectionViewCell, CellConfigurable {
         guard let vm = self.viewModel else { return }
         vm.didTap(buttonTitle: self.primaryButton.titleLabel?.text) { [weak self] in
             DispatchQueue.main.async {
-                let state: ButtonState = .enabled(vm.buttonViewModel.buttonTitle)
+                let state: ButtonState = .enabled(
+                    vm.buttonViewModel.buttonTitle,
+                    vm.buttonViewModel.buttonBackgroundColor
+                )
                 self?.primaryButton.updateButtonDesign(state: state)
             }
         }

--- a/GameDex/Common/Cells/PrimaryButtonCell.swift
+++ b/GameDex/Common/Cells/PrimaryButtonCell.swift
@@ -55,8 +55,8 @@ final class PrimaryButtonCell: UICollectionViewCell, CellConfigurable {
         vm.didTap(buttonTitle: self.primaryButton.titleLabel?.text) { [weak self] in
             DispatchQueue.main.async {
                 let state: ButtonState = .enabled(
-                    vm.buttonViewModel.buttonTitle,
-                    vm.buttonViewModel.buttonBackgroundColor
+                    vm.buttonViewModel.title,
+                    vm.buttonViewModel.backgroundColor
                 )
                 self?.primaryButton.updateButtonDesign(state: state)
             }

--- a/GameDex/Common/ContentViewFactory/PrimaryButtonContentViewFactory.swift
+++ b/GameDex/Common/ContentViewFactory/PrimaryButtonContentViewFactory.swift
@@ -16,8 +16,8 @@ final class PrimaryButtonContentViewFactory: ContentViewFactory {
         continueButton.configure(
             viewModel: ButtonViewModel(
                 isEnabled: shouldEnable,
-                buttonTitle: self.buttonTitle,
-                buttonBackgroundColor: .secondaryColor
+                title: self.buttonTitle,
+                backgroundColor: .secondaryColor
             )
         )
         continueButton.layoutMargins = UIEdgeInsets(

--- a/GameDex/Common/ContentViewFactory/PrimaryButtonContentViewFactory.swift
+++ b/GameDex/Common/ContentViewFactory/PrimaryButtonContentViewFactory.swift
@@ -16,7 +16,8 @@ final class PrimaryButtonContentViewFactory: ContentViewFactory {
         continueButton.configure(
             viewModel: ButtonViewModel(
                 isEnabled: shouldEnable,
-                buttonTitle: self.buttonTitle
+                buttonTitle: self.buttonTitle,
+                buttonBackgroundColor: .secondaryColor
             )
         )
         continueButton.layoutMargins = UIEdgeInsets(

--- a/GameDex/DesignSystem/Components/ButtonState.swift
+++ b/GameDex/DesignSystem/Components/ButtonState.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import UIKit
 
 enum ButtonState {
     case loading
-    case enabled(String)
+    case enabled(String, UIColor)
     case disabled(String)
 }

--- a/GameDex/DesignSystem/Components/ButtonViewModel.swift
+++ b/GameDex/DesignSystem/Components/ButtonViewModel.swift
@@ -10,16 +10,16 @@ import UIKit
 
 struct ButtonViewModel {
     let isEnabled: Bool
-    let buttonTitle: String
-    let buttonBackgroundColor: UIColor
+    let title: String
+    let backgroundColor: UIColor
     
     init(
         isEnabled: Bool = true,
-        buttonTitle: String,
-        buttonBackgroundColor: UIColor
+        title: String,
+        backgroundColor: UIColor
     ) {
         self.isEnabled = isEnabled
-        self.buttonTitle = buttonTitle
-        self.buttonBackgroundColor = buttonBackgroundColor
+        self.title = title
+        self.backgroundColor = backgroundColor
     }
 }

--- a/GameDex/DesignSystem/Components/ButtonViewModel.swift
+++ b/GameDex/DesignSystem/Components/ButtonViewModel.swift
@@ -6,13 +6,20 @@
 //
 
 import Foundation
+import UIKit
 
 struct ButtonViewModel {
     let isEnabled: Bool
-    let buttonTitle: String    
+    let buttonTitle: String
+    let buttonBackgroundColor: UIColor
     
-    init(isEnabled: Bool = true, buttonTitle: String) {
+    init(
+        isEnabled: Bool = true,
+        buttonTitle: String,
+        buttonBackgroundColor: UIColor
+    ) {
         self.isEnabled = isEnabled
         self.buttonTitle = buttonTitle
+        self.buttonBackgroundColor = buttonBackgroundColor
     }
 }

--- a/GameDex/DesignSystem/Components/PrimaryButton.swift
+++ b/GameDex/DesignSystem/Components/PrimaryButton.swift
@@ -54,7 +54,7 @@ final class PrimaryButton: UIButton {
         self.titleLabel?.textAlignment = .center
         self.titleLabel?.numberOfLines = DesignSystem.numberOfLinesStandard
         self.setTitleColor(.primaryBackgroundColor, for: .normal)
-        let state: ButtonState = viewModel.isEnabled ? .enabled(viewModel.buttonTitle) : .disabled(viewModel.buttonTitle)
+        let state: ButtonState = viewModel.isEnabled ? .enabled(viewModel.buttonTitle, viewModel.buttonBackgroundColor) : .disabled(viewModel.buttonTitle)
         self.updateButtonDesign(state: state)
         self.setupConstraints()
     }
@@ -102,10 +102,10 @@ final class PrimaryButton: UIButton {
             self.showLoader()
             self.setTitle(nil, for: [])
             self.backgroundColor = .systemGray3
-        case let .enabled(title):
+        case let .enabled(title, color):
             self.isEnabled = true
             self.setTitle(title, for: .normal)
-            self.backgroundColor = .secondaryColor
+            self.backgroundColor = color
             self.hideLoader()
         case let .disabled(title):
             self.isEnabled = false

--- a/GameDex/DesignSystem/Components/PrimaryButton.swift
+++ b/GameDex/DesignSystem/Components/PrimaryButton.swift
@@ -54,7 +54,7 @@ final class PrimaryButton: UIButton {
         self.titleLabel?.textAlignment = .center
         self.titleLabel?.numberOfLines = DesignSystem.numberOfLinesStandard
         self.setTitleColor(.primaryBackgroundColor, for: .normal)
-        let state: ButtonState = viewModel.isEnabled ? .enabled(viewModel.buttonTitle, viewModel.buttonBackgroundColor) : .disabled(viewModel.buttonTitle)
+        let state: ButtonState = viewModel.isEnabled ? .enabled(viewModel.title, viewModel.backgroundColor) : .disabled(viewModel.title)
         self.updateButtonDesign(state: state)
         self.setupConstraints()
     }

--- a/GameDex/MyProfile/Authentication/AuthenticationSection.swift
+++ b/GameDex/MyProfile/Authentication/AuthenticationSection.swift
@@ -38,7 +38,10 @@ final class AuthenticationSection: Section {
         self.cellsVM.append(passwordTextField)
         
         let loginButtonCellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(buttonTitle: userHasAccount ? L10n.login : L10n.createAccount),
+            buttonViewModel: ButtonViewModel(
+                buttonTitle: userHasAccount ? L10n.login : L10n.createAccount,
+                buttonBackgroundColor: .secondaryColor
+            ),
             delegate: primaryButtonDelegate
         )
         self.cellsVM.append(loginButtonCellVM)

--- a/GameDex/MyProfile/Authentication/AuthenticationSection.swift
+++ b/GameDex/MyProfile/Authentication/AuthenticationSection.swift
@@ -39,8 +39,8 @@ final class AuthenticationSection: Section {
         
         let loginButtonCellVM = PrimaryButtonCellViewModel(
             buttonViewModel: ButtonViewModel(
-                buttonTitle: userHasAccount ? L10n.login : L10n.createAccount,
-                buttonBackgroundColor: .secondaryColor
+                title: userHasAccount ? L10n.login : L10n.createAccount,
+                backgroundColor: .secondaryColor
             ),
             delegate: primaryButtonDelegate
         )

--- a/GameDex/MyProfile/CollectionManagement/CollectionManagementSection.swift
+++ b/GameDex/MyProfile/CollectionManagement/CollectionManagementSection.swift
@@ -42,7 +42,10 @@ final class CollectionManagementSection: Section {
         self.cellsVM.append(collectionCellVM)
         
         let deleteCollectionButtonCellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(buttonTitle: L10n.deleteFromCollection),
+            buttonViewModel: ButtonViewModel(
+                buttonTitle: L10n.deleteFromCollection,
+                buttonBackgroundColor: .primaryColor
+            ),
             delegate: primaryButtonDelegate,
             buttonType: .classic            
         )

--- a/GameDex/MyProfile/CollectionManagement/CollectionManagementSection.swift
+++ b/GameDex/MyProfile/CollectionManagement/CollectionManagementSection.swift
@@ -43,8 +43,8 @@ final class CollectionManagementSection: Section {
         
         let deleteCollectionButtonCellVM = PrimaryButtonCellViewModel(
             buttonViewModel: ButtonViewModel(
-                buttonTitle: L10n.deleteFromCollection,
-                buttonBackgroundColor: .primaryColor
+                title: L10n.deleteFromCollection,
+                backgroundColor: .primaryColor
             ),
             delegate: primaryButtonDelegate,
             buttonType: .classic            

--- a/GameDex/MyProfile/EditProfile/EditProfileSection.swift
+++ b/GameDex/MyProfile/EditProfile/EditProfileSection.swift
@@ -39,8 +39,8 @@ final class EditProfileSection: Section {
         
         let updateProfileButtonCellVM = PrimaryButtonCellViewModel(
             buttonViewModel: ButtonViewModel(
-                buttonTitle: credentialsConfirmed ? L10n.saveChanges : L10n.confirm,
-                buttonBackgroundColor: .secondaryColor
+                title: credentialsConfirmed ? L10n.saveChanges : L10n.confirm,
+                backgroundColor: .secondaryColor
             ),
             delegate: primaryButtonDelegate
         )
@@ -49,8 +49,8 @@ final class EditProfileSection: Section {
         if credentialsConfirmed {
             let deleteProfileButtonCellVM = PrimaryButtonCellViewModel(
                 buttonViewModel: ButtonViewModel(
-                    buttonTitle: L10n.deleteAccount,
-                    buttonBackgroundColor: .primaryColor
+                    title: L10n.deleteAccount,
+                    backgroundColor: .primaryColor
                 ),
                 delegate: primaryButtonDelegate,
                 buttonType: .warning

--- a/GameDex/MyProfile/EditProfile/EditProfileSection.swift
+++ b/GameDex/MyProfile/EditProfile/EditProfileSection.swift
@@ -38,14 +38,20 @@ final class EditProfileSection: Section {
         self.cellsVM.append(passwordTextFieldCellVM)
         
         let updateProfileButtonCellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(buttonTitle: credentialsConfirmed ? L10n.saveChanges : L10n.confirm),
+            buttonViewModel: ButtonViewModel(
+                buttonTitle: credentialsConfirmed ? L10n.saveChanges : L10n.confirm,
+                buttonBackgroundColor: .secondaryColor
+            ),
             delegate: primaryButtonDelegate
         )
         self.cellsVM.append(updateProfileButtonCellVM)
         
         if credentialsConfirmed {
             let deleteProfileButtonCellVM = PrimaryButtonCellViewModel(
-                buttonViewModel: ButtonViewModel(buttonTitle: L10n.deleteAccount),
+                buttonViewModel: ButtonViewModel(
+                    buttonTitle: L10n.deleteAccount,
+                    buttonBackgroundColor: .primaryColor
+                ),
                 delegate: primaryButtonDelegate,
                 buttonType: .warning
             )

--- a/GameDex/MyProfile/Login/LoginSection.swift
+++ b/GameDex/MyProfile/Login/LoginSection.swift
@@ -29,8 +29,8 @@ final class LoginSection: Section {
         
         let loginButtonCellVM = PrimaryButtonCellViewModel(
             buttonViewModel: ButtonViewModel(
-                buttonTitle: L10n.login,
-                buttonBackgroundColor: .secondaryColor
+                title: L10n.login,
+                backgroundColor: .secondaryColor
             ),
             delegate: primaryButtonDelegate
         )
@@ -38,8 +38,8 @@ final class LoginSection: Section {
         
         let signupButtonCellVM = PrimaryButtonCellViewModel(
             buttonViewModel: ButtonViewModel(
-                buttonTitle: L10n.createAccount,
-                buttonBackgroundColor: .secondaryColor
+                title: L10n.createAccount,
+                backgroundColor: .secondaryColor
             ),
             delegate: primaryButtonDelegate
         )

--- a/GameDex/MyProfile/Login/LoginSection.swift
+++ b/GameDex/MyProfile/Login/LoginSection.swift
@@ -28,14 +28,20 @@ final class LoginSection: Section {
         self.cellsVM.append(titleCellVM)
         
         let loginButtonCellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(buttonTitle: L10n.login),
-            delegate: primaryButtonDelegate            
+            buttonViewModel: ButtonViewModel(
+                buttonTitle: L10n.login,
+                buttonBackgroundColor: .secondaryColor
+            ),
+            delegate: primaryButtonDelegate
         )
         self.cellsVM.append(loginButtonCellVM)
         
         let signupButtonCellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(buttonTitle: L10n.createAccount),
-            delegate: primaryButtonDelegate            
+            buttonViewModel: ButtonViewModel(
+                buttonTitle: L10n.createAccount,
+                buttonBackgroundColor: .secondaryColor
+            ),
+            delegate: primaryButtonDelegate
         )
         
         self.cellsVM.append(signupButtonCellVM)

--- a/GameDexTests/Common/CellsViewModel/PrimaryButtonCellViewModelTests.swift
+++ b/GameDexTests/Common/CellsViewModel/PrimaryButtonCellViewModelTests.swift
@@ -16,11 +16,11 @@ final class PrimaryButtonCellViewModelTests: XCTestCase {
         
         // When
         let cellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(buttonTitle: title),
+            buttonViewModel: ButtonViewModel(buttonTitle: title, buttonBackgroundColor: .secondaryColor),
             delegate: PrimaryButtonDelegateMock()
         )
         // Then
-        let expectedButtonVM = ButtonViewModel(buttonTitle: title)
+        let expectedButtonVM = ButtonViewModel(buttonTitle: title, buttonBackgroundColor: .secondaryColor)
         XCTAssertEqual(cellVM.buttonViewModel, expectedButtonVM)
         XCTAssertEqual(cellVM.reuseIdentifier, "\(cellVM.cellClass)")
     }
@@ -28,7 +28,7 @@ final class PrimaryButtonCellViewModelTests: XCTestCase {
     func test_didTap_ThenShouldCallDelegate() {
         // Given
         let delegate = PrimaryButtonDelegateMock()
-        let viewModel = PrimaryButtonCellViewModel(buttonViewModel: ButtonViewModel(buttonTitle: "title"), delegate: delegate)
+        let viewModel = PrimaryButtonCellViewModel(buttonViewModel: ButtonViewModel(buttonTitle: "title", buttonBackgroundColor: .secondaryColor), delegate: delegate)
         
         // When
         viewModel.didTap(buttonTitle: "title") {

--- a/GameDexTests/Common/CellsViewModel/PrimaryButtonCellViewModelTests.swift
+++ b/GameDexTests/Common/CellsViewModel/PrimaryButtonCellViewModelTests.swift
@@ -16,11 +16,11 @@ final class PrimaryButtonCellViewModelTests: XCTestCase {
         
         // When
         let cellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(buttonTitle: title, buttonBackgroundColor: .secondaryColor),
+            buttonViewModel: ButtonViewModel(title: title, backgroundColor: .secondaryColor),
             delegate: PrimaryButtonDelegateMock()
         )
         // Then
-        let expectedButtonVM = ButtonViewModel(buttonTitle: title, buttonBackgroundColor: .secondaryColor)
+        let expectedButtonVM = ButtonViewModel(title: title, backgroundColor: .secondaryColor)
         XCTAssertEqual(cellVM.buttonViewModel, expectedButtonVM)
         XCTAssertEqual(cellVM.reuseIdentifier, "\(cellVM.cellClass)")
     }
@@ -28,7 +28,7 @@ final class PrimaryButtonCellViewModelTests: XCTestCase {
     func test_didTap_ThenShouldCallDelegate() {
         // Given
         let delegate = PrimaryButtonDelegateMock()
-        let viewModel = PrimaryButtonCellViewModel(buttonViewModel: ButtonViewModel(buttonTitle: "title", buttonBackgroundColor: .secondaryColor), delegate: delegate)
+        let viewModel = PrimaryButtonCellViewModel(buttonViewModel: ButtonViewModel(title: "title", backgroundColor: .secondaryColor), delegate: delegate)
         
         // When
         viewModel.didTap(buttonTitle: "title") {

--- a/GameDexTests/DesignSystem/Components/ButtonViewModelTests.swift
+++ b/GameDexTests/DesignSystem/Components/ButtonViewModelTests.swift
@@ -14,7 +14,7 @@ final class ButtonViewModelTests: XCTestCase {
         // Given
         let title = "Button title"
         // When
-        let viewModel = ButtonViewModel(buttonTitle: title)
+        let viewModel = ButtonViewModel(buttonTitle: title, buttonBackgroundColor: .secondaryColor)
         // Then
         XCTAssertEqual(viewModel.buttonTitle, title)
         XCTAssertTrue(viewModel.isEnabled)

--- a/GameDexTests/DesignSystem/Components/ButtonViewModelTests.swift
+++ b/GameDexTests/DesignSystem/Components/ButtonViewModelTests.swift
@@ -14,9 +14,9 @@ final class ButtonViewModelTests: XCTestCase {
         // Given
         let title = "Button title"
         // When
-        let viewModel = ButtonViewModel(buttonTitle: title, buttonBackgroundColor: .secondaryColor)
+        let viewModel = ButtonViewModel(title: title, backgroundColor: .secondaryColor)
         // Then
-        XCTAssertEqual(viewModel.buttonTitle, title)
+        XCTAssertEqual(viewModel.title, title)
         XCTAssertTrue(viewModel.isEnabled)
     }
 }

--- a/GameDexTests/Equatables.swift
+++ b/GameDexTests/Equatables.swift
@@ -72,7 +72,7 @@ extension AlertViewModel: Equatable {
 extension ButtonViewModel: Equatable {
     public static func == (lhs: ButtonViewModel, rhs: ButtonViewModel) -> Bool {
         lhs.isEnabled == rhs.isEnabled &&
-        lhs.buttonTitle == rhs.buttonTitle
+        lhs.title == rhs.title
     }
 }
 

--- a/GameDexTests/MyProfile/Authentication/AuthenticationSectionTests.swift
+++ b/GameDexTests/MyProfile/Authentication/AuthenticationSectionTests.swift
@@ -28,7 +28,7 @@ final class AuthenticationSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.loginEmail)
-        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.login, buttonBackgroundColor: .secondaryColor))
+        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.login, backgroundColor: .secondaryColor))
         
         
         
@@ -80,7 +80,7 @@ final class AuthenticationSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.signupEmail)
-        XCTAssertEqual(createAccountButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.createAccount, buttonBackgroundColor: .secondaryColor))
+        XCTAssertEqual(createAccountButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.createAccount, backgroundColor: .secondaryColor))
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in
             return cellVM is (any FormCellViewModel)

--- a/GameDexTests/MyProfile/Authentication/AuthenticationSectionTests.swift
+++ b/GameDexTests/MyProfile/Authentication/AuthenticationSectionTests.swift
@@ -28,7 +28,7 @@ final class AuthenticationSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.loginEmail)
-        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.login))
+        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.login, buttonBackgroundColor: .secondaryColor))
         
         
         
@@ -80,7 +80,7 @@ final class AuthenticationSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.signupEmail)
-        XCTAssertEqual(createAccountButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.createAccount))
+        XCTAssertEqual(createAccountButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.createAccount, buttonBackgroundColor: .secondaryColor))
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in
             return cellVM is (any FormCellViewModel)

--- a/GameDexTests/MyProfile/CollectionManagement/CollectionManagementSectionTests.swift
+++ b/GameDexTests/MyProfile/CollectionManagement/CollectionManagementSectionTests.swift
@@ -30,7 +30,7 @@ final class CollectionManagementSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.selectAndDeleteACollection)
-        XCTAssertEqual(deleteCollectionButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.deleteFromCollection))
+        XCTAssertEqual(deleteCollectionButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.deleteFromCollection, buttonBackgroundColor: .primaryColor))
         XCTAssertEqual(deleteCollectionButtonCellVM.buttonType, .classic)
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in

--- a/GameDexTests/MyProfile/CollectionManagement/CollectionManagementSectionTests.swift
+++ b/GameDexTests/MyProfile/CollectionManagement/CollectionManagementSectionTests.swift
@@ -30,7 +30,7 @@ final class CollectionManagementSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.selectAndDeleteACollection)
-        XCTAssertEqual(deleteCollectionButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.deleteFromCollection, buttonBackgroundColor: .primaryColor))
+        XCTAssertEqual(deleteCollectionButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.deleteFromCollection, backgroundColor: .primaryColor))
         XCTAssertEqual(deleteCollectionButtonCellVM.buttonType, .classic)
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in

--- a/GameDexTests/MyProfile/EditProfile/EditProfileSectionTests.swift
+++ b/GameDexTests/MyProfile/EditProfile/EditProfileSectionTests.swift
@@ -34,9 +34,9 @@ final class EditProfileSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.updateCredentials)
-        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.saveChanges))
+        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.saveChanges, buttonBackgroundColor: .secondaryColor))
         XCTAssertEqual(updateProfileButtonCellVM.buttonType, .classic)
-        XCTAssertEqual(deleteProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.deleteAccount))
+        XCTAssertEqual(deleteProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.deleteAccount, buttonBackgroundColor: .primaryColor))
         XCTAssertEqual(deleteProfileButtonCellVM.buttonType, .warning)
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in
@@ -94,7 +94,7 @@ final class EditProfileSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.confirmCredentials)
-        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.confirm))
+        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.confirm, buttonBackgroundColor: .secondaryColor))
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in
             return cellVM is (any FormCellViewModel)

--- a/GameDexTests/MyProfile/EditProfile/EditProfileSectionTests.swift
+++ b/GameDexTests/MyProfile/EditProfile/EditProfileSectionTests.swift
@@ -34,9 +34,9 @@ final class EditProfileSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.updateCredentials)
-        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.saveChanges, buttonBackgroundColor: .secondaryColor))
+        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.saveChanges, backgroundColor: .secondaryColor))
         XCTAssertEqual(updateProfileButtonCellVM.buttonType, .classic)
-        XCTAssertEqual(deleteProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.deleteAccount, buttonBackgroundColor: .primaryColor))
+        XCTAssertEqual(deleteProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.deleteAccount, backgroundColor: .primaryColor))
         XCTAssertEqual(deleteProfileButtonCellVM.buttonType, .warning)
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in
@@ -94,7 +94,7 @@ final class EditProfileSectionTests: XCTestCase {
         }
         
         XCTAssertEqual(titleCellVM.title, L10n.confirmCredentials)
-        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.confirm, buttonBackgroundColor: .secondaryColor))
+        XCTAssertEqual(updateProfileButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.confirm, backgroundColor: .secondaryColor))
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in
             return cellVM is (any FormCellViewModel)

--- a/GameDexTests/MyProfile/Login/LoginSectionTests.swift
+++ b/GameDexTests/MyProfile/Login/LoginSectionTests.swift
@@ -29,7 +29,7 @@ final class LoginSectionTests: XCTestCase {
         
         XCTAssertEqual(imageCellVM.imageName, Asset.devices.name)
         XCTAssertEqual(titleCellVM.title, L10n.loginDescription)
-        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.login))
-        XCTAssertEqual(signupButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.createAccount))
+        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.login, buttonBackgroundColor: .secondaryColor))
+        XCTAssertEqual(signupButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.createAccount, buttonBackgroundColor: .secondaryColor))
     }
 }

--- a/GameDexTests/MyProfile/Login/LoginSectionTests.swift
+++ b/GameDexTests/MyProfile/Login/LoginSectionTests.swift
@@ -29,7 +29,7 @@ final class LoginSectionTests: XCTestCase {
         
         XCTAssertEqual(imageCellVM.imageName, Asset.devices.name)
         XCTAssertEqual(titleCellVM.title, L10n.loginDescription)
-        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.login, buttonBackgroundColor: .secondaryColor))
-        XCTAssertEqual(signupButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, buttonTitle: L10n.createAccount, buttonBackgroundColor: .secondaryColor))
+        XCTAssertEqual(loginButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.login, backgroundColor: .secondaryColor))
+        XCTAssertEqual(signupButtonCellVM.buttonViewModel, ButtonViewModel(isEnabled: true, title: L10n.createAccount, backgroundColor: .secondaryColor))
     }
 }


### PR DESCRIPTION
ISSUE : 
When tapping primaryButton, the background color was updated to .secondaryColor automatically.
it was an issue for buttons used to delete content as they should remain with .primaryColor as backgroundColor.
The issue was due to the backgroundColor being updated by the viewModel ButtonState (.enabled).

HOW IT WAS FIXED : 
The backgroundColor is now passed by the ButtonViewModel to the buttonState