### PR TITLE
Feature/display games type physical or digital

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,6 +21,7 @@ disabled_rules:
     - for_where
     - unused_optional_binding
     - type_name
+    - self_in_property_initialization
 
 line_length: 250
 

--- a/GameDex.xcodeproj/project.pbxproj
+++ b/GameDex.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		254E8B912A8B6BC000C101C8 /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254E8B902A8B6BC000C101C8 /* Assets.swift */; };
 		254E8B942A8B6BCA00C101C8 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254E8B932A8B6BCA00C101C8 /* Strings.swift */; };
 		255A0A482C035DDD007ED3D3 /* GameFilterFormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A472C035DDD007ED3D3 /* GameFilterFormType.swift */; };
+		255A0A4A2C05BF4A007ED3D3 /* SegmentedControlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A492C05BF4A007ED3D3 /* SegmentedControlCell.swift */; };
+		255A0A4C2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A4B2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift */; };
 		255F8EBA2BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255F8EB92BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift */; };
 		255F8EBC2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255F8EBB2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift */; };
 		2560B0172ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2560B0162ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift */; };
@@ -290,6 +292,8 @@
 		254E8B902A8B6BC000C101C8 /* Assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
 		254E8B932A8B6BCA00C101C8 /* Strings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		255A0A472C035DDD007ED3D3 /* GameFilterFormType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameFilterFormType.swift; sourceTree = "<group>"; };
+		255A0A492C05BF4A007ED3D3 /* SegmentedControlCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCell.swift; sourceTree = "<group>"; };
+		255A0A4B2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCellViewModel.swift; sourceTree = "<group>"; };
 		255F8EB92BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionFiltersViewModelTests.swift; sourceTree = "<group>"; };
 		255F8EBB2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionFiltersSectionTests.swift; sourceTree = "<group>"; };
 		2560B0162ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityCheckerImpl.swift; sourceTree = "<group>"; };
@@ -822,6 +826,7 @@
 				25979DAF2ABF17C5002CEDE7 /* PrimaryButtonCell.swift */,
 				25979DB32ABF1E07002CEDE7 /* TitleCell.swift */,
 				25979DCB2AC17C22002CEDE7 /* ImageCell.swift */,
+				255A0A492C05BF4A007ED3D3 /* SegmentedControlCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -838,6 +843,7 @@
 				25979DB12ABF17D1002CEDE7 /* PrimaryButtonCellViewModel.swift */,
 				25979DB52ABF1E1B002CEDE7 /* TitleCellViewModel.swift */,
 				25979DCD2AC17C2C002CEDE7 /* ImageCellViewModel.swift */,
+				255A0A4B2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift */,
 			);
 			path = CellsViewModel;
 			sourceTree = "<group>";
@@ -1532,6 +1538,7 @@
 				25DA8CB82AADE7E300B40F84 /* SavedGame.swift in Sources */,
 				2506D8AC2AE93504006D3F52 /* CollectionManagementScreenFactory.swift in Sources */,
 				25D6EAE22A8A265C00C2BE57 /* AppDelegate.swift in Sources */,
+				255A0A4C2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift in Sources */,
 				25AE1F1D2A8F926400F2D06A /* ContentViewFactory.swift in Sources */,
 				25EB242C2AA621800024F01C /* ImageDescriptionCell.swift in Sources */,
 				256D9C422AD2BD9700D4AA23 /* Position.swift in Sources */,
@@ -1554,6 +1561,7 @@
 				25EB24322AA631730024F01C /* TextViewCell.swift in Sources */,
 				25EB241E2AA602FB0024F01C /* UIImageView+Extension.swift in Sources */,
 				251C86BA2A97A29D0020C794 /* APIError.swift in Sources */,
+				255A0A4A2C05BF4A007ED3D3 /* SegmentedControlCell.swift in Sources */,
 				25EB244C2AA8AC120024F01C /* GameCompleteness.swift in Sources */,
 				2560B0172ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift in Sources */,
 				2506D8932AE02668006D3F52 /* EditProfileScreenFactory.swift in Sources */,

--- a/GameDex.xcodeproj/project.pbxproj
+++ b/GameDex.xcodeproj/project.pbxproj
@@ -78,6 +78,9 @@
 		255A0A4A2C05BF4A007ED3D3 /* SegmentedControlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A492C05BF4A007ED3D3 /* SegmentedControlCell.swift */; };
 		255A0A4C2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A4B2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift */; };
 		255A0A502C072A88007ED3D3 /* FirestoreQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A4F2C072A88007ED3D3 /* FirestoreQuery.swift */; };
+		255A0A522C072BDF007ED3D3 /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A512C072BDF007ED3D3 /* SegmentItem.swift */; };
+		255A0A542C072C89007ED3D3 /* GameFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A532C072C89007ED3D3 /* GameFormat.swift */; };
+		255A0A562C072F20007ED3D3 /* LabelAndIconSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A552C072F20007ED3D3 /* LabelAndIconSegment.swift */; };
 		255F8EBA2BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255F8EB92BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift */; };
 		255F8EBC2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255F8EBB2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift */; };
 		2560B0172ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2560B0162ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift */; };
@@ -296,6 +299,9 @@
 		255A0A492C05BF4A007ED3D3 /* SegmentedControlCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCell.swift; sourceTree = "<group>"; };
 		255A0A4B2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCellViewModel.swift; sourceTree = "<group>"; };
 		255A0A4F2C072A88007ED3D3 /* FirestoreQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreQuery.swift; sourceTree = "<group>"; };
+		255A0A512C072BDF007ED3D3 /* SegmentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentItem.swift; sourceTree = "<group>"; };
+		255A0A532C072C89007ED3D3 /* GameFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameFormat.swift; sourceTree = "<group>"; };
+		255A0A552C072F20007ED3D3 /* LabelAndIconSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelAndIconSegment.swift; sourceTree = "<group>"; };
 		255F8EB92BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionFiltersViewModelTests.swift; sourceTree = "<group>"; };
 		255F8EBB2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionFiltersSectionTests.swift; sourceTree = "<group>"; };
 		2560B0162ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityCheckerImpl.swift; sourceTree = "<group>"; };
@@ -565,6 +571,7 @@
 				2506D8962AE026B2006D3F52 /* ButtonType.swift */,
 				258630382BFCB43A00AD3EE4 /* GameFilter.swift */,
 				255A0A472C035DDD007ED3D3 /* GameFilterFormType.swift */,
+				255A0A512C072BDF007ED3D3 /* SegmentItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -676,6 +683,7 @@
 				25EB24492AA8ABCB0024F01C /* GameRegion.swift */,
 				25EB244B2AA8AC120024F01C /* GameCompleteness.swift */,
 				25EB244D2AA8AC210024F01C /* GameCondition.swift */,
+				255A0A532C072C89007ED3D3 /* GameFormat.swift */,
 			);
 			path = GameProperties;
 			sourceTree = "<group>";
@@ -811,6 +819,7 @@
 				2506D8772ADD39B3006D3F52 /* VerticallyAlignedLabel.swift */,
 				2506D8812ADE992F006D3F52 /* AppLauncherImpl.swift */,
 				2506D8B62AF7CA4A006D3F52 /* ButtonState.swift */,
+				255A0A552C072F20007ED3D3 /* LabelAndIconSegment.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1442,6 +1451,7 @@
 				2506D8972AE026B2006D3F52 /* ButtonType.swift in Sources */,
 				258630352BF7982B00AD3EE4 /* MyCollectionFiltersScreenFactory.swift in Sources */,
 				251C86F82A9A307A0020C794 /* UISearchBar+Configure.swift in Sources */,
+				255A0A522C072BDF007ED3D3 /* SegmentItem.swift in Sources */,
 				25EB241A2AA5F8940024F01C /* AddGameDetailsScreenFactory.swift in Sources */,
 				2560B0192ACFF1DF00EBAADB /* InfoContentViewFactory.swift in Sources */,
 				25BDEC8A2AC5781C0083E0B2 /* FirestoreDatabase.swift in Sources */,
@@ -1535,6 +1545,8 @@
 				2506D87C2ADE97CB006D3F52 /* AppLauncher.swift in Sources */,
 				25E8E4B12AC428880093E7F8 /* AuthenticationServiceImpl.swift in Sources */,
 				25979DA42ABF0D5D002CEDE7 /* BasicCardCell.swift in Sources */,
+				255A0A562C072F20007ED3D3 /* LabelAndIconSegment.swift in Sources */,
+				255A0A542C072C89007ED3D3 /* GameFormat.swift in Sources */,
 				25939FFB2AAF5D01000FC253 /* AlertDisplayerImpl.swift in Sources */,
 				25AE1EBE2A8CB85900F2D06A /* CellViewModel.swift in Sources */,
 				2506D8A82AE934E9006D3F52 /* CollectionManagementViewModel.swift in Sources */,

--- a/GameDex.xcodeproj/project.pbxproj
+++ b/GameDex.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		25AE1F302A92234000F2D06A /* UINavigationController+ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AE1F2F2A92234000F2D06A /* UINavigationController+ProgressBar.swift */; };
 		25AE1F3B2A938F6600F2D06A /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 25AE1F3A2A938F6600F2D06A /* .swiftlint.yml */; };
 		25AE1F3D2A939BE300F2D06A /* ButtonViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AE1F3C2A939BE300F2D06A /* ButtonViewModelTests.swift */; };
+		25BA88812C09C9FE00B8CD28 /* GameForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA88802C09C9FE00B8CD28 /* GameForm.swift */; };
 		25BDEC8A2AC5781C0083E0B2 /* FirestoreDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BDEC892AC5781C0083E0B2 /* FirestoreDatabase.swift */; };
 		25D5074D2AB61BB200A772F9 /* MyCollectionSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5074C2AB61BB200A772F9 /* MyCollectionSectionTests.swift */; };
 		25D507512AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D507502AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift */; };
@@ -373,6 +374,7 @@
 		25AE1F2F2A92234000F2D06A /* UINavigationController+ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+ProgressBar.swift"; sourceTree = "<group>"; };
 		25AE1F3A2A938F6600F2D06A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		25AE1F3C2A939BE300F2D06A /* ButtonViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonViewModelTests.swift; sourceTree = "<group>"; };
+		25BA88802C09C9FE00B8CD28 /* GameForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameForm.swift; sourceTree = "<group>"; };
 		25BDEC892AC5781C0083E0B2 /* FirestoreDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreDatabase.swift; sourceTree = "<group>"; };
 		25D5074C2AB61BB200A772F9 /* MyCollectionSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionSectionTests.swift; sourceTree = "<group>"; };
 		25D507502AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionByPlatformSectionTests.swift; sourceTree = "<group>"; };
@@ -572,6 +574,7 @@
 				258630382BFCB43A00AD3EE4 /* GameFilter.swift */,
 				255A0A472C035DDD007ED3D3 /* GameFilterFormType.swift */,
 				255A0A512C072BDF007ED3D3 /* SegmentItem.swift */,
+				25BA88802C09C9FE00B8CD28 /* GameForm.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1548,6 +1551,7 @@
 				255A0A562C072F20007ED3D3 /* LabelAndIconSegment.swift in Sources */,
 				255A0A542C072C89007ED3D3 /* GameFormat.swift in Sources */,
 				25939FFB2AAF5D01000FC253 /* AlertDisplayerImpl.swift in Sources */,
+				25BA88812C09C9FE00B8CD28 /* GameForm.swift in Sources */,
 				25AE1EBE2A8CB85900F2D06A /* CellViewModel.swift in Sources */,
 				2506D8A82AE934E9006D3F52 /* CollectionManagementViewModel.swift in Sources */,
 				251C86D62A9899F40020C794 /* Platform.swift in Sources */,

--- a/GameDex.xcodeproj/project.pbxproj
+++ b/GameDex.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		255A0A482C035DDD007ED3D3 /* GameFilterFormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A472C035DDD007ED3D3 /* GameFilterFormType.swift */; };
 		255A0A4A2C05BF4A007ED3D3 /* SegmentedControlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A492C05BF4A007ED3D3 /* SegmentedControlCell.swift */; };
 		255A0A4C2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A4B2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift */; };
+		255A0A502C072A88007ED3D3 /* FirestoreQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A0A4F2C072A88007ED3D3 /* FirestoreQuery.swift */; };
 		255F8EBA2BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255F8EB92BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift */; };
 		255F8EBC2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255F8EBB2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift */; };
 		2560B0172ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2560B0162ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift */; };
@@ -294,6 +295,7 @@
 		255A0A472C035DDD007ED3D3 /* GameFilterFormType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameFilterFormType.swift; sourceTree = "<group>"; };
 		255A0A492C05BF4A007ED3D3 /* SegmentedControlCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCell.swift; sourceTree = "<group>"; };
 		255A0A4B2C05BF54007ED3D3 /* SegmentedControlCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCellViewModel.swift; sourceTree = "<group>"; };
+		255A0A4F2C072A88007ED3D3 /* FirestoreQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreQuery.swift; sourceTree = "<group>"; };
 		255F8EB92BFF765600DFE8D4 /* MyCollectionFiltersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionFiltersViewModelTests.swift; sourceTree = "<group>"; };
 		255F8EBB2BFF768300DFE8D4 /* MyCollectionFiltersSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionFiltersSectionTests.swift; sourceTree = "<group>"; };
 		2560B0162ACFEEEC00EBAADB /* ConnectivityCheckerImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityCheckerImpl.swift; sourceTree = "<group>"; };
@@ -875,6 +877,7 @@
 				2506D8982AE11291006D3F52 /* FirestoreSession.swift */,
 				2506D89C2AE16B1E006D3F52 /* FirestoreSessionImpl.swift */,
 				2506D89A2AE16B08006D3F52 /* FirestoreData.swift */,
+				255A0A4F2C072A88007ED3D3 /* FirestoreQuery.swift */,
 			);
 			path = Firestore;
 			sourceTree = "<group>";
@@ -1420,6 +1423,7 @@
 				25AE1ECB2A8D1B1E00F2D06A /* MyCollectionViewModel.swift in Sources */,
 				251C86D42A9899A70020C794 /* RemoteDataConverter.swift in Sources */,
 				25EB24182AA5F7440024F01C /* StarRatingCellViewModel.swift in Sources */,
+				255A0A502C072A88007ED3D3 /* FirestoreQuery.swift in Sources */,
 				25AE1F042A8F4A6200F2D06A /* Routing.swift in Sources */,
 				252E377F2AD81BE300987DD5 /* AuthSession.swift in Sources */,
 				25979DC82AC172A9002CEDE7 /* AuthenticationSection.swift in Sources */,

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
@@ -22,6 +22,12 @@ final class AddGameDetailsSection: Section {
         )
         self.cellsVM.append(gameCellVM)
         
+        let isPhysicalCellVM = SegmentedControlCellViewModel(
+            segments: [L10n.physical, L10n.digital],
+            formType: GameFormType.isPhysical
+        )
+        self.cellsVM.append(isPhysicalCellVM)
+        
         let yearOfAcquisitionCellVM = TextFieldCellViewModel(
             placeholder: L10n.yearOfAcquisition,
             formType: GameFormType.yearOfAcquisition

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
@@ -9,7 +9,12 @@ import Foundation
 
 final class AddGameDetailsSection: Section {
     
-    init(game: Game, platform: Platform) {
+    init(
+        game: Game,
+        platform: Platform,
+        gameForm: GameForm,
+        formDelegate: FormDelegate
+    ) {
         super.init()
         self.position = 0
         
@@ -27,71 +32,89 @@ final class AddGameDetailsSection: Section {
                 SegmentItemViewModel(title: GameFormat.physical.text, image: GameFormat.physical.image),
                 SegmentItemViewModel(title: GameFormat.digital.text, image: GameFormat.digital.image)
             ],
-            formType: GameFormType.isPhysical
+            formType: GameFormType.isPhysical,
+            value: gameForm.isPhysical ? GameFormat.physical.text : GameFormat.digital.text,
+            formDelegate: formDelegate
         )
         self.cellsVM.append(isPhysicalCellVM)
         
         let yearOfAcquisitionCellVM = TextFieldCellViewModel(
             placeholder: L10n.yearOfAcquisition,
-            formType: GameFormType.yearOfAcquisition
+            formType: GameFormType.yearOfAcquisition,
+            value: gameForm.acquisitionYear,
+            formDelegate: formDelegate
         )
         self.cellsVM.append(yearOfAcquisitionCellVM)
         
-        let conditionCellVM = TextFieldCellViewModel(
-            placeholder: L10n.condition,
-            formType: GameFormType.gameCondition(
-                PickerViewModel(
-                    data: [GameCondition.allCases.compactMap {
-                        guard $0 != .unknown else {
-                            return nil
-                        }
-                        return $0.value
-                    }]
-                )
+        if gameForm.isPhysical {
+            let conditionCellVM = TextFieldCellViewModel(
+                placeholder: L10n.condition,
+                formType: GameFormType.gameCondition(
+                    PickerViewModel(
+                        data: [GameCondition.allCases.compactMap {
+                            guard $0 != .unknown else {
+                                return nil
+                            }
+                            return $0.value
+                        }]
+                    )
+                ),
+                value: gameForm.gameCondition?.value,
+                formDelegate: formDelegate
             )
-        )
-        self.cellsVM.append(conditionCellVM)
-        
-        let completenessCellVM = TextFieldCellViewModel(
-            placeholder: L10n.completeness,
-            formType: GameFormType.gameCompleteness(
-                PickerViewModel(
-                    data: [GameCompleteness.allCases.compactMap {
-                        guard $0 != .unknown else {
-                            return nil
-                        }
-                        return $0.value
-                    }]
-                )
+            self.cellsVM.append(conditionCellVM)
+            
+            let completenessCellVM = TextFieldCellViewModel(
+                placeholder: L10n.completeness,
+                formType: GameFormType.gameCompleteness(
+                    PickerViewModel(
+                        data: [GameCompleteness.allCases.compactMap {
+                            guard $0 != .unknown else {
+                                return nil
+                            }
+                            return $0.value
+                        }]
+                    )
+                ),
+                value: gameForm.gameCompleteness?.value,
+                formDelegate: formDelegate
             )
-        )
-        self.cellsVM.append(completenessCellVM)
-        
-        let regionCellVM = TextFieldCellViewModel(
-            placeholder: L10n.region,
-            formType: GameFormType.gameRegion(
-                PickerViewModel(
-                    data: [GameRegion.allCases.map { $0.value }]
-                )
+            self.cellsVM.append(completenessCellVM)
+            
+            let regionCellVM = TextFieldCellViewModel(
+                placeholder: L10n.region,
+                formType: GameFormType.gameRegion(
+                    PickerViewModel(
+                        data: [GameRegion.allCases.map { $0.value }]
+                    )
+                ),
+                value: gameForm.gameRegion?.value,
+                formDelegate: formDelegate
             )
-        )
-        self.cellsVM.append(regionCellVM)
-        
-        let storageAreaCellVM = TextFieldCellViewModel(
-            placeholder: L10n.storageArea,
-            formType: GameFormType.storageArea
-        )
-        self.cellsVM.append(storageAreaCellVM)
+            self.cellsVM.append(regionCellVM)
+            
+            let storageAreaCellVM = TextFieldCellViewModel(
+                placeholder: L10n.storageArea,
+                formType: GameFormType.storageArea,
+                value: gameForm.storageArea,
+                formDelegate: formDelegate
+            )
+            self.cellsVM.append(storageAreaCellVM)
+        }
         
         let personalRatingCellVM = StarRatingCellViewModel(
             title: L10n.personalRating,
-            formType: GameFormType.rating
+            formType: GameFormType.rating,
+            value: gameForm.rating,
+            formDelegate: formDelegate
         )
         self.cellsVM.append(personalRatingCellVM)
         
         let otherDetailsCellVM = TextViewCellViewModel(
             title: L10n.otherDetails,
-            formType: GameFormType.notes
+            formType: GameFormType.notes,
+            value: gameForm.notes,
+            formDelegate: formDelegate
         )
         self.cellsVM.append(otherDetailsCellVM)
     }

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
@@ -23,7 +23,10 @@ final class AddGameDetailsSection: Section {
         self.cellsVM.append(gameCellVM)
         
         let isPhysicalCellVM = SegmentedControlCellViewModel(
-            segments: [L10n.physical, L10n.digital],
+            segments: [
+                SegmentItemViewModel(title: GameFormat.physical.text, image: GameFormat.physical.image),
+                SegmentItemViewModel(title: GameFormat.digital.text, image: GameFormat.digital.image)
+            ],
             formType: GameFormType.isPhysical
         )
         self.cellsVM.append(isPhysicalCellVM)

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsSection.swift
@@ -40,7 +40,7 @@ final class AddGameDetailsSection: Section {
         
         let yearOfAcquisitionCellVM = TextFieldCellViewModel(
             placeholder: L10n.yearOfAcquisition,
-            formType: GameFormType.yearOfAcquisition,
+            formType: GameFormType.acquisitionYear,
             value: gameForm.acquisitionYear,
             formDelegate: formDelegate
         )

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
@@ -148,9 +148,9 @@ private extension AddGameDetailsViewModel {
             case .isPhysical:
                 let isPhysicalText = formCellVM.value as? String
                 switch isPhysicalText {
-                case L10n.physical:
+                case GameFormat.physical.text:
                     isPhysical = true
-                case L10n.digital:
+                case GameFormat.digital.text:
                     isPhysical = false
                 default:
                     break

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
@@ -144,6 +144,8 @@ private extension AddGameDetailsViewModel {
                 rating = formCellVM.value as? Int
             case .notes:
                 notes = formCellVM.value as? String
+            case .isPhysical:
+                break
             }
         }
         

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
@@ -95,7 +95,7 @@ extension AddGameDetailsViewModel: FormDelegate {
             return
         }
         switch formType {
-        case .yearOfAcquisition:
+        case .acquisitionYear:
             self.gameForm.acquisitionYear = value as? String
         case .gameCondition(_):
             if let stringValue = value as? String {

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
@@ -114,6 +114,7 @@ private extension AddGameDetailsViewModel {
         var gameCondition: GameCondition?
         var gameCompleteness: GameCompleteness?
         var gameRegion: GameRegion?
+        var isPhysical: Bool = true
         
         for formCellVM in formCellsVM {
             guard let formType = formCellVM.formType as? GameFormType else { return nil }
@@ -145,7 +146,15 @@ private extension AddGameDetailsViewModel {
             case .notes:
                 notes = formCellVM.value as? String
             case .isPhysical:
-                break
+                let isPhysicalText = formCellVM.value as? String
+                switch isPhysicalText {
+                case L10n.physical:
+                    isPhysical = true
+                case L10n.digital:
+                    isPhysical = false
+                default:
+                    break
+                }
             }
         }
         
@@ -163,7 +172,7 @@ private extension AddGameDetailsViewModel {
             rating: rating,
             notes: notes,
             lastUpdated: Date(), 
-            isPhysical: true // TODO: Update after adding selector to define if game is digital or physical
+            isPhysical: isPhysical
         )
     }
     

--- a/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
+++ b/GameDex/AddGame/AddGameDetails/AddGameDetailsViewModel.swift
@@ -188,8 +188,7 @@ private extension AddGameDetailsViewModel {
         guard let error = await self.cloudDatabase.saveGame(
             userId: userId,
             game: gameToSave,
-            platform: self.platform,
-            editingEntry: false
+            platform: self.platform
         ) else {
             await self.handleSuccess()
             return

--- a/GameDex/Common/Cells/SegmentedControlCell.swift
+++ b/GameDex/Common/Cells/SegmentedControlCell.swift
@@ -46,11 +46,14 @@ class SegmentedControlCell: UICollectionViewCell, CellConfigurable {
         }
         self.cellVM = cellVM
         self.setupConstraints()
-        self.segmentedControl.segments = LabelSegment.segments(
-            withTitles: cellVM.segments,
+        self.segmentedControl.segments = LabelAndIconSegment.segments(
+            with: cellVM.segments,
             normalTextColor: .secondaryColor,
-            selectedTextColor: .primaryBackgroundColor
+            selectedTextColor: .primaryBackgroundColor,
+            normalIconTintColor: .secondaryColor,
+            selectedIconTintColor: .primaryBackgroundColor
         )
+        
         self.segmentedControl.setIndex(cellVM.selectedSegmentIndex)
     }
     
@@ -59,7 +62,7 @@ class SegmentedControlCell: UICollectionViewCell, CellConfigurable {
             return
         }
         let index = sender.index
-        cellVM.value = cellVM.segments[index]
+        cellVM.value = cellVM.segments[index].title
     }
     
     private func setupViews() {

--- a/GameDex/Common/Cells/SegmentedControlCell.swift
+++ b/GameDex/Common/Cells/SegmentedControlCell.swift
@@ -20,10 +20,13 @@ class SegmentedControlCell: UICollectionViewCell, CellConfigurable {
         control.setOptions([
             .backgroundColor(.secondaryBackgroundColor),
             .indicatorViewBackgroundColor(.secondaryColor),
-            .cornerRadius(DesignSystem.cornerRadiusBig),
-            .animationSpringDamping(Constants.segmentedControlAnimation)
-        ])
-        control.addTarget(self, action: #selector(segmentedControlValueChanged(_:)), for: .valueChanged)
+            .cornerRadius(DesignSystem.cornerRadiusBig)
+        ])        
+        control.addTarget(
+            self,
+            action: #selector(segmentedControlValueChanged(_:)),
+            for: .valueChanged
+        )        
         control.translatesAutoresizingMaskIntoConstraints = false
         return control
     }()
@@ -53,8 +56,8 @@ class SegmentedControlCell: UICollectionViewCell, CellConfigurable {
             normalIconTintColor: .secondaryColor,
             selectedIconTintColor: .primaryBackgroundColor
         )
-        
         self.segmentedControl.setIndex(cellVM.selectedSegmentIndex)
+        self.addNotificationObservers()
     }
     
     @objc func segmentedControlValueChanged(_ sender: BetterSegmentedControl) {
@@ -63,6 +66,22 @@ class SegmentedControlCell: UICollectionViewCell, CellConfigurable {
         }
         let index = sender.index
         cellVM.value = cellVM.segments[index].title
+    }
+    
+    private func addNotificationObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleSegmentedControlInteraction), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleSegmentedControlInteraction), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc private func handleSegmentedControlInteraction(notification: NSNotification) {
+        switch notification.name {
+        case UIResponder.keyboardWillShowNotification:
+            self.segmentedControl.isUserInteractionEnabled = false
+        case UIResponder.keyboardWillHideNotification:
+            self.segmentedControl.isUserInteractionEnabled = true
+        default:
+            break
+        }
     }
     
     private func setupViews() {

--- a/GameDex/Common/Cells/SegmentedControlCell.swift
+++ b/GameDex/Common/Cells/SegmentedControlCell.swift
@@ -1,0 +1,89 @@
+//
+//  SegmentedControlCell.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 28/05/2024.
+//
+
+import Foundation
+import UIKit
+import BetterSegmentedControl
+
+class SegmentedControlCell: UICollectionViewCell, CellConfigurable {
+    
+    private enum Constants {
+        static let segmentedControlAnimation: CGFloat = 1.0
+    }
+    
+    private let segmentedControl: BetterSegmentedControl = {
+        let control = BetterSegmentedControl()
+        control.setOptions([
+            .backgroundColor(.secondaryBackgroundColor),
+            .indicatorViewBackgroundColor(.secondaryColor),
+            .cornerRadius(DesignSystem.cornerRadiusBig),
+            .animationSpringDamping(Constants.segmentedControlAnimation)
+        ])
+        control.addTarget(self, action: #selector(segmentedControlValueChanged(_:)), for: .valueChanged)
+        control.translatesAutoresizingMaskIntoConstraints = false
+        return control
+    }()
+    
+    private var cellVM: CellViewModel?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.contentView.backgroundColor = .clear
+        self.setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        return nil
+    }
+    
+    func configure(cellViewModel: CellViewModel) {
+        guard let cellVM = cellViewModel as? SegmentedControlCellViewModel else {
+            return
+        }
+        self.cellVM = cellVM
+        self.setupConstraints()
+        self.segmentedControl.segments = LabelSegment.segments(
+            withTitles: cellVM.segments,
+            normalTextColor: .secondaryColor,
+            selectedTextColor: .primaryBackgroundColor
+        )
+        self.segmentedControl.setIndex(cellVM.selectedSegmentIndex)
+    }
+    
+    @objc func segmentedControlValueChanged(_ sender: BetterSegmentedControl) {
+        guard let cellVM = self.cellVM as? SegmentedControlCellViewModel else {
+            return
+        }
+        let index = sender.index
+        cellVM.value = cellVM.segments[index]
+    }
+    
+    private func setupViews() {
+        self.contentView.addSubview(self.segmentedControl)
+    }
+    
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            self.segmentedControl.topAnchor.constraint(
+                equalTo: self.topAnchor,
+                constant: DesignSystem.paddingSmall
+            ),
+            self.segmentedControl.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor,
+                constant: DesignSystem.paddingLarge
+            ),
+            self.segmentedControl.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor,
+                constant: -DesignSystem.paddingLarge
+            ),
+            self.segmentedControl.bottomAnchor.constraint(
+                equalTo: self.bottomAnchor,
+                constant: -DesignSystem.paddingRegular
+            )
+        ])
+    }
+}

--- a/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
@@ -1,0 +1,46 @@
+//
+//  SegmentedControlCellViewModel.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 28/05/2024.
+//
+
+import Foundation
+
+final class SegmentedControlCellViewModel: CollectionFormCellViewModel {
+    typealias ValueType = String
+    
+    var cellClass: AnyClass = SegmentedControlCell.self
+    var indexPath: IndexPath?
+    var cellTappedCallback: (() -> Void)?
+    let height: CGFloat = DesignSystem.sizeVerySmall
+    
+    let segments: [String]
+    let selectedSegmentIndex: Int
+    var formType: FormType
+    var value: ValueType? {
+        didSet {
+            self.editFormDelegate?.enableSaveButtonIfNeeded()
+        }
+    }
+    
+    weak var editFormDelegate: EditFormDelegate?
+    
+    init(segments: [String],
+         formType: FormType,
+         value: String? = nil,
+         editDelegate: EditFormDelegate? = nil
+    ) {
+        self.segments = segments
+        self.formType = formType
+        self.value = value
+        self.editFormDelegate = editDelegate
+        
+        guard let value = self.value,
+              let index = segments.firstIndex(of: value) else {
+            self.selectedSegmentIndex = .zero
+            return
+        }
+        self.selectedSegmentIndex = index
+    }
+}

--- a/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
@@ -15,7 +15,7 @@ final class SegmentedControlCellViewModel: CollectionFormCellViewModel {
     var cellTappedCallback: (() -> Void)?
     let height: CGFloat = DesignSystem.sizeVerySmall
     
-    let segments: [String]
+    let segments: [SegmentItemViewModel]
     let selectedSegmentIndex: Int
     var formType: FormType
     var value: ValueType? {
@@ -26,7 +26,7 @@ final class SegmentedControlCellViewModel: CollectionFormCellViewModel {
     
     weak var editFormDelegate: EditFormDelegate?
     
-    init(segments: [String],
+    init(segments: [SegmentItemViewModel],
          formType: FormType,
          value: String? = nil,
          editDelegate: EditFormDelegate? = nil
@@ -37,7 +37,7 @@ final class SegmentedControlCellViewModel: CollectionFormCellViewModel {
         self.editFormDelegate = editDelegate
         
         guard let value = self.value,
-              let index = segments.firstIndex(of: value) else {
+              let index = segments.firstIndex(where: { $0.title == value }) else {
             self.selectedSegmentIndex = .zero
             return
         }

--- a/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
@@ -21,6 +21,9 @@ final class SegmentedControlCellViewModel: CollectionFormCellViewModel {
     var value: ValueType? {
         didSet {
             self.formDelegate?.enableSaveButtonIfNeeded()
+            if oldValue != value {
+                self.formDelegate?.refreshSectionsDependingOnGameFormat()
+            }
         }
     }
     

--- a/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
@@ -20,8 +20,9 @@ final class SegmentedControlCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
+            self.formDelegate?.didUpdate(value: self.value as Any, for: self.formType)
             self.formDelegate?.enableSaveButtonIfNeeded()
-            if oldValue != value {
+            if oldValue != self.value {
                 self.formDelegate?.refreshSectionsDependingOnGameFormat()
             }
         }

--- a/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/SegmentedControlCellViewModel.swift
@@ -20,21 +20,21 @@ final class SegmentedControlCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
-            self.editFormDelegate?.enableSaveButtonIfNeeded()
+            self.formDelegate?.enableSaveButtonIfNeeded()
         }
     }
     
-    weak var editFormDelegate: EditFormDelegate?
+    weak var formDelegate: FormDelegate?
     
     init(segments: [SegmentItemViewModel],
          formType: FormType,
          value: String? = nil,
-         editDelegate: EditFormDelegate? = nil
+         formDelegate: FormDelegate? = nil
     ) {
         self.segments = segments
         self.formType = formType
         self.value = value
-        self.editFormDelegate = editDelegate
+        self.formDelegate = formDelegate
         
         guard let value = self.value,
               let index = segments.firstIndex(where: { $0.title == value }) else {

--- a/GameDex/Common/CellsViewModel/StarRatingCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/StarRatingCellViewModel.swift
@@ -19,20 +19,20 @@ final class StarRatingCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
-            self.editFormDelegate?.enableSaveButtonIfNeeded()
+            self.formDelegate?.enableSaveButtonIfNeeded()
         }
     }
     
-    weak var editFormDelegate: EditFormDelegate?
+    weak var formDelegate: FormDelegate?
     
     init(title: String,
          formType: FormType,
          value: Int? = nil,
-         editDelegate: EditFormDelegate? = nil
+         formDelegate: FormDelegate? = nil
     ) {
         self.title = title
         self.formType = formType
         self.value = value
-        self.editFormDelegate = editDelegate
+        self.formDelegate = formDelegate
     }
 }

--- a/GameDex/Common/CellsViewModel/StarRatingCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/StarRatingCellViewModel.swift
@@ -19,6 +19,7 @@ final class StarRatingCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
+            self.formDelegate?.didUpdate(value: self.value as Any, for: self.formType)
             self.formDelegate?.enableSaveButtonIfNeeded()
         }
     }

--- a/GameDex/Common/CellsViewModel/TextFieldCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/TextFieldCellViewModel.swift
@@ -19,21 +19,21 @@ final class TextFieldCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
-            self.editFormDelegate?.enableSaveButtonIfNeeded()
+            self.formDelegate?.enableSaveButtonIfNeeded()
         }
     }
     
-    weak var editFormDelegate: EditFormDelegate?
+    weak var formDelegate: FormDelegate?
     
     init(placeholder: String,
          formType: FormType,
          value: String? = nil,
-         editDelegate: EditFormDelegate? = nil
+         formDelegate: FormDelegate? = nil
     ) {
         self.placeholder = placeholder
         self.formType = formType
         self.value = value
-        self.editFormDelegate = editDelegate
+        self.formDelegate = formDelegate
     }
     
 }

--- a/GameDex/Common/CellsViewModel/TextFieldCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/TextFieldCellViewModel.swift
@@ -19,6 +19,7 @@ final class TextFieldCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
+            self.formDelegate?.didUpdate(value: self.value as Any, for: self.formType)
             self.formDelegate?.enableSaveButtonIfNeeded()
         }
     }

--- a/GameDex/Common/CellsViewModel/TextViewCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/TextViewCellViewModel.swift
@@ -19,20 +19,20 @@ final class TextViewCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
-            self.editFormDelegate?.enableSaveButtonIfNeeded()
+            self.formDelegate?.enableSaveButtonIfNeeded()
         }
     }
     
-    weak var editFormDelegate: EditFormDelegate?
+    weak var formDelegate: FormDelegate?
     
     init(title: String,
          formType: FormType,
          value: String? = nil,
-         editDelegate: EditFormDelegate? = nil
+         formDelegate: FormDelegate? = nil
     ) {
         self.title = title
         self.formType = formType
         self.value = value
-        self.editFormDelegate = editDelegate
+        self.formDelegate = formDelegate
     }
 }

--- a/GameDex/Common/CellsViewModel/TextViewCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/TextViewCellViewModel.swift
@@ -19,6 +19,7 @@ final class TextViewCellViewModel: CollectionFormCellViewModel {
     var formType: FormType
     var value: ValueType? {
         didSet {
+            self.formDelegate?.didUpdate(value: self.value as Any, for: self.formType)
             self.formDelegate?.enableSaveButtonIfNeeded()
         }
     }

--- a/GameDex/Common/Model/GameForm.swift
+++ b/GameDex/Common/Model/GameForm.swift
@@ -1,0 +1,19 @@
+//
+//  GameForm.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 31/05/2024.
+//
+
+import Foundation
+
+struct GameForm {
+    let isPhysical: Bool
+    let acquisitionYear: String?
+    let gameCondition: GameCondition?
+    let gameCompleteness: GameCompleteness?
+    let gameRegion: GameRegion?
+    let storageArea: String?
+    let rating: Int?
+    let notes: String?
+}

--- a/GameDex/Common/Model/GameForm.swift
+++ b/GameDex/Common/Model/GameForm.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-struct GameForm {
-    let isPhysical: Bool
-    let acquisitionYear: String?
-    let gameCondition: GameCondition?
-    let gameCompleteness: GameCompleteness?
-    let gameRegion: GameRegion?
-    let storageArea: String?
-    let rating: Int?
-    let notes: String?
+struct GameForm: Equatable {
+    var isPhysical: Bool
+    var acquisitionYear: String?
+    var gameCondition: GameCondition?
+    var gameCompleteness: GameCompleteness?
+    var gameRegion: GameRegion?
+    var storageArea: String?
+    var rating: Int
+    var notes: String?
 }

--- a/GameDex/Common/Model/GameFormType.swift
+++ b/GameDex/Common/Model/GameFormType.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 enum GameFormType: FormType, Equatable {
+    case isPhysical
     case yearOfAcquisition
     case gameCondition(PickerViewModel)
     case gameCompleteness(PickerViewModel)

--- a/GameDex/Common/Model/GameFormType.swift
+++ b/GameDex/Common/Model/GameFormType.swift
@@ -10,7 +10,7 @@ import UIKit
 
 enum GameFormType: FormType, Equatable {
     case isPhysical
-    case yearOfAcquisition
+    case acquisitionYear
     case gameCondition(PickerViewModel)
     case gameCompleteness(PickerViewModel)
     case gameRegion(PickerViewModel)
@@ -22,7 +22,7 @@ enum GameFormType: FormType, Equatable {
         switch self {
         case .storageArea, .notes:
             return .asciiCapable
-        case .yearOfAcquisition:
+        case .acquisitionYear:
             return .asciiCapableNumberPad
         default:
             return nil

--- a/GameDex/Common/Model/GameProperties/GameFormat.swift
+++ b/GameDex/Common/Model/GameProperties/GameFormat.swift
@@ -1,0 +1,32 @@
+//
+//  GameFormat.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 29/05/2024.
+//
+
+import Foundation
+import UIKit
+
+enum GameFormat: CaseIterable {
+    case physical
+    case digital
+    
+    var text: String {
+        switch self {
+        case .physical:
+            L10n.physical
+        case .digital:
+            L10n.digital
+        }
+    }
+    
+    var image: UIImage {
+        switch self {
+        case .physical:
+            return UIImage(systemName: "menucard")!
+        case .digital:
+            return UIImage(systemName: "cloud")!
+        }
+    }
+}

--- a/GameDex/Common/Model/SavedGame.swift
+++ b/GameDex/Common/Model/SavedGame.swift
@@ -14,7 +14,7 @@ struct SavedGame {
     let gameCompleteness: GameCompleteness?
     let gameRegion: GameRegion?
     let storageArea: String?
-    let rating: Int?
+    let rating: Int
     let notes: String?
     let lastUpdated: Date
     let isPhysical: Bool

--- a/GameDex/Common/Model/SegmentItem.swift
+++ b/GameDex/Common/Model/SegmentItem.swift
@@ -1,0 +1,14 @@
+//
+//  SegmentItemViewModel.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 29/05/2024.
+//
+
+import Foundation
+import UIKit
+
+struct SegmentItemViewModel {
+    let title: String
+    let image: UIImage?
+}

--- a/GameDex/CoreData/CoreDataConverter.swift
+++ b/GameDex/CoreData/CoreDataConverter.swift
@@ -56,6 +56,7 @@ enum CoreDataConverter {
         gameCollected.gameID = gameDetails.game.id
         gameCollected.releaseDate = gameDetails.game.releaseDate
         gameCollected.lastUpdated = gameDetails.lastUpdated
+        gameCollected.isPhysical = gameDetails.isPhysical
     
         return gameCollected
     }

--- a/GameDex/CoreData/LocalDatabaseImpl.swift
+++ b/GameDex/CoreData/LocalDatabaseImpl.swift
@@ -44,7 +44,7 @@ extension LocalDatabaseImpl {
             }
             if platformResult.gamesArray.contains(
                 where: { aGame in
-                    aGame.title == newEntity.game.title
+                    aGame.title == newEntity.game.title && aGame.isPhysical == newEntity.isPhysical
                 }
             ) {
                 return DatabaseError.itemAlreadySaved
@@ -128,6 +128,7 @@ extension LocalDatabaseImpl {
             gameToReplace.notes = savedGame.notes
             gameToReplace.rating = Int16(savedGame.rating ?? .zero)
             gameToReplace.storageArea = savedGame.storageArea
+            gameToReplace.isPhysical = savedGame.isPhysical
             
             // Save the context
             guard await self.coreDataStack.saveContext(self.managedObjectContext) == nil else {

--- a/GameDex/DesignSystem/Components/LabelAndIconSegment.swift
+++ b/GameDex/DesignSystem/Components/LabelAndIconSegment.swift
@@ -107,7 +107,7 @@ class LabelAndIconSegment: BetterSegmentedControlSegment {
                          withIcon icon: UIImage? = nil,
                          iconSize: CGSize? = nil,
                          iconTintColor: UIColor? = nil,
-                         accessibilityIdentifier: String?) -> UIView {
+                         accessibilityIdentifier: String? = nil) -> UIView {
         let view = UIView()
         view.backgroundColor = backgroundColor
         view.layoutMargins = .init(

--- a/GameDex/DesignSystem/Components/LabelAndIconSegment.swift
+++ b/GameDex/DesignSystem/Components/LabelAndIconSegment.swift
@@ -1,0 +1,206 @@
+//
+//  LabelAndIconSegment.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 29/05/2024.
+//
+
+import Foundation
+import BetterSegmentedControl
+
+class LabelAndIconSegment: BetterSegmentedControlSegment {
+    
+    // MARK: Constants
+    private struct DefaultValues {
+        static let normalBackgroundColor: UIColor = .clear
+        static let normalTextColor: UIColor = .black
+        static let normalFont: UIFont = .systemFont(ofSize: 13)
+        static let selectedBackgroundColor: UIColor = .clear
+        static let selectedTextColor: UIColor = .black
+        static let selectedFont: UIFont = .systemFont(ofSize: 13, weight: .medium)
+    }
+    
+    // MARK: Properties
+    public let text: String
+    
+    public let normalFont: UIFont
+    public let normalTextColor: UIColor
+    public let normalBackgroundColor: UIColor
+    public let selectedFont: UIFont
+    public let selectedTextColor: UIColor
+    public let selectedBackgroundColor: UIColor
+    
+    private let numberOfLines: Int
+    private let accessibilityIdentifier: String?
+    
+    public var icon: UIImage?
+    public var iconSize: CGSize?
+    public var normalIconTintColor: UIColor?
+    public var selectedIconTintColor: UIColor?
+    
+    // MARK: Lifecycle
+    public init(text: String,
+                numberOfLines: Int = 1,
+                normalBackgroundColor: UIColor? = nil,
+                normalFont: UIFont? = nil,
+                normalTextColor: UIColor? = nil,
+                selectedBackgroundColor: UIColor? = nil,
+                selectedFont: UIFont? = nil,
+                selectedTextColor: UIColor? = nil,
+                accessibilityIdentifier: String? = nil,
+                icon: UIImage? = nil,
+                iconSize: CGSize? = nil,
+                normalIconTintColor: UIColor? = nil,
+                selectedIconTintColor: UIColor? = nil
+    ) {
+        self.text = text
+        self.numberOfLines = numberOfLines
+        self.normalBackgroundColor = normalBackgroundColor ?? DefaultValues.normalBackgroundColor
+        self.normalFont = normalFont ?? DefaultValues.normalFont
+        self.normalTextColor = normalTextColor ?? DefaultValues.normalTextColor
+        self.selectedBackgroundColor = selectedBackgroundColor ?? DefaultValues.selectedBackgroundColor
+        self.selectedFont = selectedFont ?? DefaultValues.selectedFont
+        self.selectedTextColor = selectedTextColor ?? DefaultValues.selectedTextColor
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.icon = icon?.withRenderingMode(.alwaysTemplate)
+        self.iconSize = iconSize
+        self.normalIconTintColor = normalIconTintColor
+        self.selectedIconTintColor = selectedIconTintColor
+    }
+    
+    // MARK: BetterSegmentedControlSegment
+    public var intrinsicContentSize: CGSize? {
+        selectedView.intrinsicContentSize
+    }
+    //    public var intrinsicContentSize: CGSize? { nil }
+    
+    public lazy var normalView: UIView = {
+        createView(
+            withText: self.text,
+            backgroundColor: self.normalBackgroundColor,
+            font: self.normalFont,
+            textColor: self.normalTextColor,
+            withIcon: self.icon,
+            iconSize: self.iconSize,
+            iconTintColor: self.normalIconTintColor,
+            accessibilityIdentifier: self.accessibilityIdentifier
+        )
+    }()
+    
+    public lazy var selectedView: UIView = {
+        createView(
+            withText: self.text,
+            backgroundColor: self.selectedBackgroundColor,
+            font: self.selectedFont,
+            textColor: self.selectedTextColor,
+            withIcon: self.icon,
+            iconSize: self.iconSize,
+            iconTintColor: self.selectedIconTintColor,
+            accessibilityIdentifier: self.accessibilityIdentifier
+        )
+    }()
+    
+    open func createView(withText text: String,
+                         backgroundColor: UIColor,
+                         font: UIFont,
+                         textColor: UIColor,
+                         withIcon icon: UIImage? = nil,
+                         iconSize: CGSize? = nil,
+                         iconTintColor: UIColor? = nil,
+                         accessibilityIdentifier: String?) -> UIView {
+        let view = UIView()
+        view.backgroundColor = backgroundColor
+        view.layoutMargins = .init(
+            top: DesignSystem.paddingRegular,
+            left: DesignSystem.paddingRegular,
+            bottom: DesignSystem.paddingRegular,
+            right: DesignSystem.paddingRegular
+        )
+        
+        let label = UILabel()
+        label.text = text
+        label.numberOfLines = numberOfLines
+        label.backgroundColor = .clear
+        label.font = font
+        label.textColor = textColor
+        label.lineBreakMode = .byTruncatingTail
+        label.textAlignment = .center
+        label.accessibilityIdentifier = accessibilityIdentifier
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        if let icon = icon {
+            let imageView = UIImageView(image: icon)
+//            imageView.frame = CGRect(
+//                x: 0,
+//                y: 0,
+//                width: iconSize?.width ?? DesignSystem.sizeTiny,
+//                height: iconSize?.height ?? DesignSystem.sizeTiny
+//            )
+            imageView.contentMode = .scaleAspectFit
+            imageView.tintColor = iconTintColor
+            imageView.autoresizingMask = [
+                .flexibleTopMargin,
+                .flexibleLeftMargin,
+                .flexibleRightMargin,
+                .flexibleBottomMargin
+            ]
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(imageView)
+            view.addSubview(label)
+            
+            NSLayoutConstraint.activate([
+                imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: DesignSystem.paddingLarge),
+                imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: DesignSystem.paddingRegular),
+                imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -DesignSystem.paddingRegular),
+                imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
+                
+                label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor),
+                label.topAnchor.constraint(equalTo: view.topAnchor),
+                label.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -DesignSystem.paddingLarge)
+            ])
+        } else {
+            view.addSubview(label)
+        }
+        return view
+    }
+}
+
+extension LabelAndIconSegment {
+    class func segments(with segments: [SegmentItemViewModel],
+                        numberOfLines: Int = 1,
+                        normalBackgroundColor: UIColor? = nil,
+                        normalFont: UIFont? = nil,
+                        normalTextColor: UIColor? = nil,
+                        selectedBackgroundColor: UIColor? = nil,
+                        selectedFont: UIFont? = nil,
+                        selectedTextColor: UIColor? = nil,
+                        iconSize: CGSize? = nil,
+                        normalIconTintColor: UIColor? = nil,
+                        selectedIconTintColor: UIColor? = nil
+    ) -> [BetterSegmentedControlSegment] {
+        var segmentControlSegments = [BetterSegmentedControlSegment]()
+        
+        for segment in segments {
+            segmentControlSegments.append(
+                LabelAndIconSegment(
+                    text: segment.title,
+                    numberOfLines: numberOfLines,
+                    normalBackgroundColor: normalBackgroundColor,
+                    normalFont: normalFont,
+                    normalTextColor: normalTextColor,
+                    selectedBackgroundColor: selectedBackgroundColor,
+                    selectedFont: selectedFont,
+                    selectedTextColor: selectedTextColor,
+                    accessibilityIdentifier: nil,
+                    icon: segment.image,
+                    iconSize: iconSize,
+                    normalIconTintColor: normalIconTintColor,
+                    selectedIconTintColor: selectedIconTintColor
+                )
+            )
+        }
+        
+        return segmentControlSegments
+    }
+}

--- a/GameDex/DesignSystem/Components/LabelAndIconSegment.swift
+++ b/GameDex/DesignSystem/Components/LabelAndIconSegment.swift
@@ -130,12 +130,6 @@ class LabelAndIconSegment: BetterSegmentedControlSegment {
         
         if let icon = icon {
             let imageView = UIImageView(image: icon)
-//            imageView.frame = CGRect(
-//                x: 0,
-//                y: 0,
-//                width: iconSize?.width ?? DesignSystem.sizeTiny,
-//                height: iconSize?.height ?? DesignSystem.sizeTiny
-//            )
             imageView.contentMode = .scaleAspectFit
             imageView.tintColor = iconTintColor
             imageView.autoresizingMask = [

--- a/GameDex/Firestore/FirestoreDatabase.swift
+++ b/GameDex/Firestore/FirestoreDatabase.swift
@@ -484,7 +484,7 @@ private extension FirestoreDatabase {
         case searchPlatform
         case userPlatforms(String)
         case userGames(String, String)
-        case userGame(String, String, String)
+//        case userGame(String, String, String)
         case users
         case apiKey
         case searchGamesApi
@@ -497,8 +497,8 @@ private extension FirestoreDatabase {
                 return "users/\(userId)/platforms"
             case let .userGames(userId, platformId):
                 return "users/\(userId)/platforms/\(platformId)/games"
-            case let .userGame(userId, platformId, gameId):
-                return "users/\(userId)/platforms/\(platformId)/games/\(gameId)"
+//            case let .userGame(userId, platformId, gameId):
+//                return "users/\(userId)/platforms/\(platformId)/games/\(gameId)"
             case .users:
                 return "users"
             case .apiKey:

--- a/GameDex/Firestore/FirestoreDatabase.swift
+++ b/GameDex/Firestore/FirestoreDatabase.swift
@@ -312,7 +312,7 @@ class FirestoreDatabase: CloudDatabase {
                       path: Collections.userGames(userId, "\(savedGame.game.platformId)").path,
                       directory: gameUUID
                   ) == nil else {
-                return DatabaseError.fetchError
+                return DatabaseError.removeError
             }
             // once game is deleted, we have to check if the platform still has other games. If not, then we delete the plaform from database.
             let fetchPlatformResult = await self.getSinglePlatformCollection(userId: userId, platform: platform)

--- a/GameDex/Firestore/FirestoreDatabase.swift
+++ b/GameDex/Firestore/FirestoreDatabase.swift
@@ -484,7 +484,6 @@ private extension FirestoreDatabase {
         case searchPlatform
         case userPlatforms(String)
         case userGames(String, String)
-//        case userGame(String, String, String)
         case users
         case apiKey
         case searchGamesApi
@@ -497,8 +496,6 @@ private extension FirestoreDatabase {
                 return "users/\(userId)/platforms"
             case let .userGames(userId, platformId):
                 return "users/\(userId)/platforms/\(platformId)/games"
-//            case let .userGame(userId, platformId, gameId):
-//                return "users/\(userId)/platforms/\(platformId)/games/\(gameId)"
             case .users:
                 return "users"
             case .apiKey:

--- a/GameDex/Firestore/FirestoreQuery.swift
+++ b/GameDex/Firestore/FirestoreQuery.swift
@@ -1,0 +1,13 @@
+//
+//  FirestoreQuery.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 29/05/2024.
+//
+
+import Foundation
+
+struct FirestoreQuery {
+    let key: String
+    let value: Any
+}

--- a/GameDex/Firestore/FirestoreSession.swift
+++ b/GameDex/Firestore/FirestoreSession.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // sourcery: AutoMockable
 protocol FirestoreSession {
-    func getData(mainPath: String) async -> Result<[FirestoreData], DatabaseError>
+    func getData(mainPath: String, condition: FirestoreQuery?) async -> Result<[FirestoreData], DatabaseError>
     func getSingleData(path: String, directory: String) async -> Result<FirestoreData, DatabaseError>
     func setData(path: String, firestoreData: FirestoreData) async -> DatabaseError?
     func deleteData(path: String, directory: String) async -> DatabaseError? 

--- a/GameDex/Helpers/Protocols/CellViewModel.swift
+++ b/GameDex/Helpers/Protocols/CellViewModel.swift
@@ -55,4 +55,9 @@ protocol FormCellViewModel {
 protocol FormDelegate: AnyObject {
     func enableSaveButtonIfNeeded()
     func refreshSectionsDependingOnGameFormat()
+    func didUpdate(value: Any, for type: FormType)
+}
+
+extension FormDelegate {
+    func enableSaveButtonIfNeeded() {}
 }

--- a/GameDex/Helpers/Protocols/CellViewModel.swift
+++ b/GameDex/Helpers/Protocols/CellViewModel.swift
@@ -54,4 +54,5 @@ protocol FormCellViewModel {
 // sourcery: AutoMockable
 protocol FormDelegate: AnyObject {
     func enableSaveButtonIfNeeded()
+    func refreshSectionsDependingOnGameFormat()
 }

--- a/GameDex/Helpers/Protocols/CellViewModel.swift
+++ b/GameDex/Helpers/Protocols/CellViewModel.swift
@@ -48,10 +48,10 @@ protocol FormCellViewModel {
     
     var formType: FormType { get set }
     var value: ValueType? { get set }
-    var editFormDelegate: EditFormDelegate? { get }
+    var formDelegate: FormDelegate? { get }
 }
 
 // sourcery: AutoMockable
-protocol EditFormDelegate: AnyObject {
+protocol FormDelegate: AnyObject {
     func enableSaveButtonIfNeeded()
 }

--- a/GameDex/Helpers/Protocols/CloudDatabase.swift
+++ b/GameDex/Helpers/Protocols/CloudDatabase.swift
@@ -13,13 +13,16 @@ protocol CloudDatabase {
     func getSinglePlatformCollection(userId: String, platform: Platform) async -> Result<Platform, DatabaseError>
     func getUserCollection(userId: String) async -> Result<[Platform], DatabaseError>
     func getAvailablePlatforms() async -> Result<[Platform], DatabaseError>
+    func getGameUUID(userId: String, newGame: SavedGame, oldGame: SavedGame) async -> Result<String?, DatabaseError>
     
     func saveUser(userId: String, userEmail: String) async -> DatabaseError?
     func saveUserEmail(userId: String, userEmail: String) async -> DatabaseError?
     func saveGames(userId: String, platform: Platform) async -> DatabaseError?
-    func saveGame(userId: String, game: SavedGame, platform: Platform, editingEntry: Bool) async -> DatabaseError?
+    func saveGame(userId: String, game: SavedGame, platform: Platform) async -> DatabaseError?
     func savePlatform(userId: String, platform: Platform) async -> DatabaseError? 
     func saveCollection(userId: String, localDatabase: LocalDatabase) async -> DatabaseError?
+    
+    func replaceGame(userId: String, newGame: SavedGame, oldGame: SavedGame, platform: Platform) async -> DatabaseError?
     
     func gameIsInDatabase(userId: String, savedGame: SavedGame) async -> Result<Bool, DatabaseError>
     

--- a/GameDex/Helpers/Protocols/CloudDatabase.swift
+++ b/GameDex/Helpers/Protocols/CloudDatabase.swift
@@ -13,7 +13,7 @@ protocol CloudDatabase {
     func getSinglePlatformCollection(userId: String, platform: Platform) async -> Result<Platform, DatabaseError>
     func getUserCollection(userId: String) async -> Result<[Platform], DatabaseError>
     func getAvailablePlatforms() async -> Result<[Platform], DatabaseError>
-    func getGameUUID(userId: String, newGame: SavedGame, oldGame: SavedGame) async -> Result<String?, DatabaseError>
+    func getGameUUID(userId: String, newGame: SavedGame?, oldGame: SavedGame) async -> Result<String?, DatabaseError>
     
     func saveUser(userId: String, userEmail: String) async -> DatabaseError?
     func saveUserEmail(userId: String, userEmail: String) async -> DatabaseError?
@@ -23,6 +23,8 @@ protocol CloudDatabase {
     func saveCollection(userId: String, localDatabase: LocalDatabase) async -> DatabaseError?
     
     func replaceGame(userId: String, newGame: SavedGame, oldGame: SavedGame, platform: Platform) async -> DatabaseError?
+    
+    func isSameGame(savedGame: SavedGame, firestoreGameData: FirestoreData) -> Bool
     
     func gameIsInDatabase(userId: String, savedGame: SavedGame) async -> Result<Bool, DatabaseError>
     

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
@@ -41,59 +41,61 @@ final class EditGameDetailsSection: Section {
         )
         self.cellsVM.append(yearOfAcquisitionCellVM)
         
-        let conditionCellVM = TextFieldCellViewModel(
-            placeholder: L10n.condition,
-            formType: GameFormType.gameCondition(
-                PickerViewModel(
-                    data: [GameCondition.allCases.compactMap {
-                        guard $0 != .unknown else {
-                            return nil
-                        }
-                        return $0.value
-                    }]
-                )
-            ),
-            value: savedGame.gameCondition?.value,
-            formDelegate: formDelegate
-        )
-        self.cellsVM.append(conditionCellVM)
-        
-        let completenessCellVM = TextFieldCellViewModel(
-            placeholder: L10n.completeness,
-            formType: GameFormType.gameCompleteness(
-                PickerViewModel(
-                    data: [GameCompleteness.allCases.compactMap {
-                        guard $0 != .unknown else {
-                            return nil
-                        }
-                        return $0.value
-                    }]
-                )
-            ),
-            value: savedGame.gameCompleteness?.value,
-            formDelegate: formDelegate
-        )
-        self.cellsVM.append(completenessCellVM)
-        
-        let regionCellVM = TextFieldCellViewModel(
-            placeholder: L10n.region,
-            formType: GameFormType.gameRegion(
-                PickerViewModel(
-                    data: [GameRegion.allCases.map { $0.value }]
-                )
-            ),
-            value: savedGame.gameRegion?.value,
-            formDelegate: formDelegate
-        )
-        self.cellsVM.append(regionCellVM)
-        
-        let storageAreaCellVM = TextFieldCellViewModel(
-            placeholder: L10n.storageArea,
-            formType: GameFormType.storageArea,
-            value: savedGame.storageArea,
-            formDelegate: formDelegate
-        )
-        self.cellsVM.append(storageAreaCellVM)
+        if savedGame.isPhysical {
+            let conditionCellVM = TextFieldCellViewModel(
+                placeholder: L10n.condition,
+                formType: GameFormType.gameCondition(
+                    PickerViewModel(
+                        data: [GameCondition.allCases.compactMap {
+                            guard $0 != .unknown else {
+                                return nil
+                            }
+                            return $0.value
+                        }]
+                    )
+                ),
+                value: savedGame.gameCondition?.value,
+                formDelegate: formDelegate
+            )
+            self.cellsVM.append(conditionCellVM)
+            
+            let completenessCellVM = TextFieldCellViewModel(
+                placeholder: L10n.completeness,
+                formType: GameFormType.gameCompleteness(
+                    PickerViewModel(
+                        data: [GameCompleteness.allCases.compactMap {
+                            guard $0 != .unknown else {
+                                return nil
+                            }
+                            return $0.value
+                        }]
+                    )
+                ),
+                value: savedGame.gameCompleteness?.value,
+                formDelegate: formDelegate
+            )
+            self.cellsVM.append(completenessCellVM)
+            
+            let regionCellVM = TextFieldCellViewModel(
+                placeholder: L10n.region,
+                formType: GameFormType.gameRegion(
+                    PickerViewModel(
+                        data: [GameRegion.allCases.map { $0.value }]
+                    )
+                ),
+                value: savedGame.gameRegion?.value,
+                formDelegate: formDelegate
+            )
+            self.cellsVM.append(regionCellVM)
+            
+            let storageAreaCellVM = TextFieldCellViewModel(
+                placeholder: L10n.storageArea,
+                formType: GameFormType.storageArea,
+                value: savedGame.storageArea,
+                formDelegate: formDelegate
+            )
+            self.cellsVM.append(storageAreaCellVM)
+        }
         
         let personalRatingCellVM = StarRatingCellViewModel(
             title: L10n.personalRating,

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
@@ -35,7 +35,7 @@ final class EditGameDetailsSection: Section {
         
         let yearOfAcquisitionCellVM = TextFieldCellViewModel(
             placeholder: L10n.yearOfAcquisition,
-            formType: GameFormType.yearOfAcquisition,
+            formType: GameFormType.acquisitionYear,
             value: gameForm.acquisitionYear,
             formDelegate: formDelegate
         )

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
@@ -22,6 +22,14 @@ final class EditGameDetailsSection: Section {
         )
         self.cellsVM.append(gameCellVM)
         
+        let isPhysicalCellVM = SegmentedControlCellViewModel(
+            segments: [L10n.physical, L10n.digital],
+            formType: GameFormType.isPhysical,
+            value: savedGame.isPhysical ? L10n.physical : L10n.digital,
+            editDelegate: editDelegate
+        )
+        self.cellsVM.append(isPhysicalCellVM)
+        
         let yearOfAcquisitionCellVM = TextFieldCellViewModel(
             placeholder: L10n.yearOfAcquisition,
             formType: GameFormType.yearOfAcquisition,

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class EditGameDetailsSection: Section {
     
-    init(savedGame: SavedGame, platformName: String, editDelegate: EditFormDelegate) {
+    init(savedGame: SavedGame, platformName: String, formDelegate: FormDelegate) {
         super.init()
         self.position = 0
         
@@ -29,7 +29,7 @@ final class EditGameDetailsSection: Section {
             ],
             formType: GameFormType.isPhysical,
             value: savedGame.isPhysical ? GameFormat.physical.text : GameFormat.digital.text,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(isPhysicalCellVM)
         
@@ -37,7 +37,7 @@ final class EditGameDetailsSection: Section {
             placeholder: L10n.yearOfAcquisition,
             formType: GameFormType.yearOfAcquisition,
             value: savedGame.acquisitionYear,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(yearOfAcquisitionCellVM)
         
@@ -54,7 +54,7 @@ final class EditGameDetailsSection: Section {
                 )
             ),
             value: savedGame.gameCondition?.value,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(conditionCellVM)
         
@@ -71,7 +71,7 @@ final class EditGameDetailsSection: Section {
                 )
             ),
             value: savedGame.gameCompleteness?.value,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(completenessCellVM)
         
@@ -83,7 +83,7 @@ final class EditGameDetailsSection: Section {
                 )
             ),
             value: savedGame.gameRegion?.value,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(regionCellVM)
         
@@ -91,7 +91,7 @@ final class EditGameDetailsSection: Section {
             placeholder: L10n.storageArea,
             formType: GameFormType.storageArea,
             value: savedGame.storageArea,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(storageAreaCellVM)
         
@@ -99,7 +99,7 @@ final class EditGameDetailsSection: Section {
             title: L10n.personalRating,
             formType: GameFormType.rating,
             value: savedGame.rating,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(personalRatingCellVM)
         
@@ -107,7 +107,7 @@ final class EditGameDetailsSection: Section {
             title: L10n.otherDetails,
             formType: GameFormType.notes,
             value: savedGame.notes,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(otherDetailsCellVM)
     }

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class EditGameDetailsSection: Section {
     
-    init(savedGame: SavedGame, platformName: String, formDelegate: FormDelegate) {
+    init(savedGame: SavedGame, platformName: String, gameForm: GameForm, formDelegate: FormDelegate) {
         super.init()
         self.position = 0
         
@@ -28,7 +28,7 @@ final class EditGameDetailsSection: Section {
                 SegmentItemViewModel(title: GameFormat.digital.text, image: GameFormat.digital.image)
             ],
             formType: GameFormType.isPhysical,
-            value: savedGame.isPhysical ? GameFormat.physical.text : GameFormat.digital.text,
+            value: gameForm.isPhysical ? GameFormat.physical.text : GameFormat.digital.text,
             formDelegate: formDelegate
         )
         self.cellsVM.append(isPhysicalCellVM)
@@ -36,12 +36,12 @@ final class EditGameDetailsSection: Section {
         let yearOfAcquisitionCellVM = TextFieldCellViewModel(
             placeholder: L10n.yearOfAcquisition,
             formType: GameFormType.yearOfAcquisition,
-            value: savedGame.acquisitionYear,
+            value: gameForm.acquisitionYear,
             formDelegate: formDelegate
         )
         self.cellsVM.append(yearOfAcquisitionCellVM)
         
-        if savedGame.isPhysical {
+        if gameForm.isPhysical {
             let conditionCellVM = TextFieldCellViewModel(
                 placeholder: L10n.condition,
                 formType: GameFormType.gameCondition(
@@ -54,7 +54,7 @@ final class EditGameDetailsSection: Section {
                         }]
                     )
                 ),
-                value: savedGame.gameCondition?.value,
+                value: gameForm.gameCondition?.value,
                 formDelegate: formDelegate
             )
             self.cellsVM.append(conditionCellVM)
@@ -71,7 +71,7 @@ final class EditGameDetailsSection: Section {
                         }]
                     )
                 ),
-                value: savedGame.gameCompleteness?.value,
+                value: gameForm.gameCompleteness?.value,
                 formDelegate: formDelegate
             )
             self.cellsVM.append(completenessCellVM)
@@ -83,7 +83,7 @@ final class EditGameDetailsSection: Section {
                         data: [GameRegion.allCases.map { $0.value }]
                     )
                 ),
-                value: savedGame.gameRegion?.value,
+                value: gameForm.gameRegion?.value,
                 formDelegate: formDelegate
             )
             self.cellsVM.append(regionCellVM)
@@ -91,7 +91,7 @@ final class EditGameDetailsSection: Section {
             let storageAreaCellVM = TextFieldCellViewModel(
                 placeholder: L10n.storageArea,
                 formType: GameFormType.storageArea,
-                value: savedGame.storageArea,
+                value: gameForm.storageArea,
                 formDelegate: formDelegate
             )
             self.cellsVM.append(storageAreaCellVM)
@@ -100,7 +100,7 @@ final class EditGameDetailsSection: Section {
         let personalRatingCellVM = StarRatingCellViewModel(
             title: L10n.personalRating,
             formType: GameFormType.rating,
-            value: savedGame.rating,
+            value: gameForm.rating,
             formDelegate: formDelegate
         )
         self.cellsVM.append(personalRatingCellVM)
@@ -108,7 +108,7 @@ final class EditGameDetailsSection: Section {
         let otherDetailsCellVM = TextViewCellViewModel(
             title: L10n.otherDetails,
             formType: GameFormType.notes,
-            value: savedGame.notes,
+            value: gameForm.notes,
             formDelegate: formDelegate
         )
         self.cellsVM.append(otherDetailsCellVM)

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsSection.swift
@@ -23,9 +23,12 @@ final class EditGameDetailsSection: Section {
         self.cellsVM.append(gameCellVM)
         
         let isPhysicalCellVM = SegmentedControlCellViewModel(
-            segments: [L10n.physical, L10n.digital],
+            segments: [
+                SegmentItemViewModel(title: GameFormat.physical.text, image: GameFormat.physical.image),
+                SegmentItemViewModel(title: GameFormat.digital.text, image: GameFormat.digital.image)
+            ],
             formType: GameFormType.isPhysical,
-            value: savedGame.isPhysical ? L10n.physical : L10n.digital,
+            value: savedGame.isPhysical ? GameFormat.physical.text : GameFormat.digital.text,
             editDelegate: editDelegate
         )
         self.cellsVM.append(isPhysicalCellVM)

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
@@ -62,7 +62,7 @@ final class EditGameDetailsViewModel: CollectionViewModel {
         self.sections = [EditGameDetailsSection(
             savedGame: self.savedGame,
             platformName: self.platform.title,
-            editDelegate: self
+            formDelegate: self
         )]
         self.configureBottomView(shouldEnableButton: false)
         callback(nil)
@@ -91,7 +91,7 @@ extension EditGameDetailsViewModel: PrimaryButtonDelegate {
     }
 }
 
-extension EditGameDetailsViewModel: EditFormDelegate {
+extension EditGameDetailsViewModel: FormDelegate {
     func enableSaveButtonIfNeeded() {
         guard let firstSection = self.sections.first,
               let formCellsVM = firstSection.cellsVM.filter({ cellVM in

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
@@ -59,11 +59,7 @@ final class EditGameDetailsViewModel: CollectionViewModel {
     }
     
     func loadData(callback: @escaping (EmptyError?) -> ()) {
-        self.sections = [EditGameDetailsSection(
-            savedGame: self.savedGame,
-            platformName: self.platform.title,
-            formDelegate: self
-        )]
+        self.updateSections(with: self.savedGame)
         self.configureBottomView(shouldEnableButton: false)
         callback(nil)
     }
@@ -75,6 +71,14 @@ final class EditGameDetailsViewModel: CollectionViewModel {
         default:
             break
         }
+    }
+    
+    private func updateSections(with savedGame: SavedGame) {
+        self.sections = [EditGameDetailsSection(
+            savedGame: savedGame,
+            platformName: self.platform.title,
+            formDelegate: self
+        )]
     }
 }
 
@@ -92,6 +96,14 @@ extension EditGameDetailsViewModel: PrimaryButtonDelegate {
 }
 
 extension EditGameDetailsViewModel: FormDelegate {
+    func refreshSectionsDependingOnGameFormat() {
+        guard let editedGame = self.getGameToSave() else {
+            return
+        }
+        self.updateSections(with: editedGame)
+        self.containerDelegate?.reloadSections(emptyError: nil)
+    }
+    
     func enableSaveButtonIfNeeded() {
         guard let firstSection = self.sections.first,
               let formCellsVM = firstSection.cellsVM.filter({ cellVM in

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
@@ -40,6 +40,7 @@ final class EditGameDetailsViewModel: CollectionViewModel {
     ) {
         self.savedGame = savedGame
         self.savedValues = [
+            self.savedGame.isPhysical ? L10n.physical : L10n.digital,
             self.savedGame.acquisitionYear,
             self.savedGame.gameCondition?.value,
             self.savedGame.gameCompleteness?.value,
@@ -106,7 +107,7 @@ extension EditGameDetailsViewModel: EditFormDelegate {
         
         var shouldEnableButton = false
         for index in 0..<savedValues.count {
-            let savedValue = savedValues[index]
+            let savedValue = self.savedValues[index]
             let currentValue = currentValues[index]
             
             if currentValue == nil && savedValue != nil || currentValue != nil && savedValue == nil {
@@ -114,10 +115,10 @@ extension EditGameDetailsViewModel: EditFormDelegate {
             } else if let savedStringValue = savedValue as? String,
                       let currentStringValue = currentValue as? String {
                 shouldEnableButton = savedStringValue != currentStringValue
-            } else if let saveIntValue = savedValue as? Int,
+            } else if let savedIntValue = savedValue as? Int,
                       let currentIntValue = currentValue as? Int {
-                shouldEnableButton = saveIntValue != currentIntValue
-            }
+                shouldEnableButton = savedIntValue != currentIntValue
+            } 
             if shouldEnableButton {
                 break
             }

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
@@ -40,7 +40,7 @@ final class EditGameDetailsViewModel: CollectionViewModel {
     ) {
         self.savedGame = savedGame
         self.savedValues = [
-            self.savedGame.isPhysical ? L10n.physical : L10n.digital,
+            self.savedGame.isPhysical ? GameFormat.physical.text : GameFormat.digital.text,
             self.savedGame.acquisitionYear,
             self.savedGame.gameCondition?.value,
             self.savedGame.gameCompleteness?.value,
@@ -223,9 +223,9 @@ private extension EditGameDetailsViewModel {
             case .isPhysical:
                 let isPhysicalText = formCellVM.value as? String
                 switch isPhysicalText {
-                case L10n.physical:
+                case GameFormat.physical.text:
                     isPhysical = true
-                case L10n.digital:
+                case GameFormat.digital.text:
                     isPhysical = false
                 default:
                     break

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
@@ -17,8 +17,8 @@ final class EditGameDetailsViewModel: CollectionViewModel {
     var sections = [Section]()
     var layoutMargins: UIEdgeInsets?
     
+    var gameForm: GameForm
     private let savedGame: SavedGame
-    private var gameForm: GameForm
     private var initialGameForm: GameForm
     private let localDatabase: LocalDatabase
     private let cloudDatabase: CloudDatabase
@@ -48,7 +48,7 @@ final class EditGameDetailsViewModel: CollectionViewModel {
             gameCompleteness: savedGame.gameCompleteness,
             gameRegion: savedGame.gameRegion,
             storageArea: savedGame.storageArea,
-            rating: savedGame.rating ?? .zero,
+            rating: savedGame.rating,
             notes: savedGame.notes
         )
         self.initialGameForm = self.gameForm
@@ -95,7 +95,7 @@ extension EditGameDetailsViewModel: FormDelegate {
             return
         }
         switch formType {
-        case .yearOfAcquisition:
+        case .acquisitionYear:
             self.gameForm.acquisitionYear = value as? String
         case .gameCondition(_):
             if let stringValue = value as? String {

--- a/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
+++ b/GameDex/MyCollection/EditGameDetails/EditGameDetailsViewModel.swift
@@ -218,6 +218,8 @@ private extension EditGameDetailsViewModel {
                 rating = formCellVM.value as? Int
             case .notes:
                 notes = formCellVM.value as? String
+            case .isPhysical:
+                break
             }
         }
         

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersSection.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersSection.swift
@@ -12,7 +12,7 @@ final class MyCollectionFiltersSection: Section {
     init(
         games: [SavedGame],
         selectedFilters: [GameFilter]?,
-        editDelegate: EditFormDelegate
+        formDelegate: FormDelegate
     ) {
         super.init()
         self.position = 0
@@ -71,7 +71,7 @@ final class MyCollectionFiltersSection: Section {
                     )
                 ),
                 value: acquisitionYearFilterValue ?? nil,
-                editDelegate: editDelegate
+                formDelegate: formDelegate
             )
             self.cellsVM.append(yearOfAcquisitionCellVM)
         }
@@ -89,7 +89,7 @@ final class MyCollectionFiltersSection: Section {
                 )
             ),
             value: conditionFilterValue ?? nil,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(conditionCellVM)
         
@@ -106,7 +106,7 @@ final class MyCollectionFiltersSection: Section {
                 )
             ),
             value: completenessFilterValue ?? nil,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(completenessCellVM)
         
@@ -118,7 +118,7 @@ final class MyCollectionFiltersSection: Section {
                 )
             ),
             value: regionFilterValue ?? nil,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(regionCellVM)
         
@@ -138,7 +138,7 @@ final class MyCollectionFiltersSection: Section {
                     )
                 ),
                 value: storageAreaFilterValue ?? nil,
-                editDelegate: editDelegate
+                formDelegate: formDelegate
             )
             self.cellsVM.append(storageAreaCellVM)
         }
@@ -147,7 +147,7 @@ final class MyCollectionFiltersSection: Section {
             title: L10n.personalRating,
             formType: GameFilterFormType.rating,
             value: ratingFilterValue ?? nil,
-            editDelegate: editDelegate
+            formDelegate: formDelegate
         )
         self.cellsVM.append(personalRatingCellVM)
     }

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
@@ -37,7 +37,7 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
         self.sections = [MyCollectionFiltersSection(
             games: self.games,
             selectedFilters: self.selectedFilters,
-            editDelegate: self
+            formDelegate: self
         )]
         self.configureBottomView(shouldEnableButton: false)
         callback(nil)
@@ -52,7 +52,7 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
             self.sections = [MyCollectionFiltersSection(
                 games: self.games,
                 selectedFilters: self.selectedFilters,
-                editDelegate: self
+                formDelegate: self
             )]
             self.configureBottomView(shouldEnableButton: true)
             self.containerDelegate?.reloadSections(emptyError: nil)
@@ -138,7 +138,7 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
     }
 }
 
-extension MyCollectionFiltersViewModel: EditFormDelegate {
+extension MyCollectionFiltersViewModel: FormDelegate {
     func enableSaveButtonIfNeeded() {
         self.configureBottomView(shouldEnableButton: true)
     }

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
@@ -139,6 +139,8 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
 }
 
 extension MyCollectionFiltersViewModel: FormDelegate {
+    func didUpdate(value: Any, for type: any FormType) {}
+    
     func enableSaveButtonIfNeeded() {
         self.configureBottomView(shouldEnableButton: true)
     }

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
@@ -142,6 +142,8 @@ extension MyCollectionFiltersViewModel: FormDelegate {
     func enableSaveButtonIfNeeded() {
         self.configureBottomView(shouldEnableButton: true)
     }
+    
+    func refreshSectionsDependingOnGameFormat() {}
 }
 
 // MARK: - PrimaryButtonDelegate

--- a/GameDex/Resources/Strings.swift
+++ b/GameDex/Resources/Strings.swift
@@ -228,6 +228,8 @@ internal enum L10n {
   internal static let warningAccountDeletion = L10n.tr("Localizable", "warningAccountDeletion", fallback: "Account deletion is definitive. This will not delete data saved directly on your device")
   /// This game is already in your collection!
   internal static let warningGameAlreadyInDatabase = L10n.tr("Localizable", "warningGameAlreadyInDatabase", fallback: "This game is already in your collection!")
+  /// A game with the selected new game format already exists in your collection.
+  internal static let warningGameFormatAlreadyExists = L10n.tr("Localizable", "warningGameFormatAlreadyExists", fallback: "A game with the selected new game format already exists in your collection.")
   /// Are you sure you want to log out?
   internal static let warningLogOut = L10n.tr("Localizable", "warningLogOut", fallback: "Are you sure you want to log out?")
   /// Your collection will be deleted permanently. This won't affect the data saved locally on other devices.

--- a/GameDex/Resources/Strings.swift
+++ b/GameDex/Resources/Strings.swift
@@ -62,6 +62,8 @@ internal enum L10n {
   internal static let deleteAccount = L10n.tr("Localizable", "deleteAccount", fallback: "Delete Account")
   /// Delete from collection
   internal static let deleteFromCollection = L10n.tr("Localizable", "deleteFromCollection", fallback: "Delete from collection")
+  /// Digital
+  internal static let digital = L10n.tr("Localizable", "digital", fallback: "Digital")
   /// Edit/Delete profile
   internal static let editProfile = L10n.tr("Localizable", "editProfile", fallback: "Edit/Delete profile")
   /// Email
@@ -152,6 +154,8 @@ internal enum L10n {
   internal static let password = L10n.tr("Localizable", "password", fallback: "Password")
   /// Personal rating
   internal static let personalRating = L10n.tr("Localizable", "personalRating", fallback: "Personal rating")
+  /// Physical
+  internal static let physical = L10n.tr("Localizable", "physical", fallback: "Physical")
   /// Platform
   internal static let platform = L10n.tr("Localizable", "platform", fallback: "Platform")
   /// Poor

--- a/GameDex/Resources/en.lproj/Localizable.strings
+++ b/GameDex/Resources/en.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 "warningAccountDeletion" = "Account deletion is definitive. This will not delete data saved directly on your device";
 "warningPlatformDeletionCloud" = "Your collection will be deleted permanently. This won't affect the data saved locally on other devices.";
 "warningPlatformDeletionLocal" = "Your collection will be deleted permanently. This will only affect data saved locally on this device.";
+"warningGameFormatAlreadyExists" = "A game with the selected new game format already exists in your collection.";
 
 // Info
 "infoNoInternet" = "You're not connected to the internet, your collection might not be up to date.";

--- a/GameDex/Resources/en.lproj/Localizable.strings
+++ b/GameDex/Resources/en.lproj/Localizable.strings
@@ -133,6 +133,8 @@
 "newPassword" = "New password";
 "currentPassword" = "Current password";
 "collectionToDelete" = "Collection to delete";
+"physical" = "Physical";
+"digital" = "Digital";
 
 // Other
 "game" = "game";

--- a/GameDex/Resources/fr.lproj/Localizable.strings
+++ b/GameDex/Resources/fr.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "newPassword" = "Nouveau mot de passe";
 "currentPassword" = "Mot de passe actuel";
 "collectionToDelete" = "Collection à supprimer";
+"physical" = "Physique";
+"digital" = "Digital";
 
 // Other
 "game" = "jeu";

--- a/GameDex/Resources/fr.lproj/Localizable.strings
+++ b/GameDex/Resources/fr.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "warningAccountDeletion" = "La suppression du compte est définitive. Cela n'affecte pas les données enregistrées en local sur votre appareil.";
 "warningPlatformDeletionCloud" = "La collection ne peut pas être restaurée après suppression. Cela n'affectera pas les données sauvegardées en local sur d'autres appareils.";
 "warningPlatformDeletionLocal" = "La collection ne peut pas être restaurée après suppression. Seules les données sauvegardées en local sur votre appreils seront supprimées.";
+"warningGameFormatAlreadyExists" = "Un jeu avec le nouveau format sélectionné existe déjà dans votre collection.";
 
 // Info
 "infoNoInternet" = "Aucun accès internet, votre collection pourrait ne pas être à jour.";

--- a/GameDexTests/AddGame/AddGameDetails/AddGameDetailsSectionTests.swift
+++ b/GameDexTests/AddGame/AddGameDetails/AddGameDetailsSectionTests.swift
@@ -14,10 +14,10 @@ final class AddGameDetailsSectionTests: XCTestCase {
     
     func test_init_ThenShouldSetPropertiesCorrectly() {
         // Given
-        let section = AddGameDetailsSection(game: MockData.game, platform: MockData.platform)
+        let section = AddGameDetailsSection(game: MockData.game, platform: MockData.platform, gameForm: MockData.editedGameForm, formDelegate: FormDelegateMock())
         
         // Then
-        XCTAssertEqual(section.cellsVM.count, 8)
+        XCTAssertEqual(section.cellsVM.count, 9)
         
         guard let gameCellVM = section.cellsVM.first as? ImageDescriptionCellViewModel else {
             XCTFail("Wrong type")
@@ -42,7 +42,7 @@ final class AddGameDetailsSectionTests: XCTestCase {
                 return
             }
             switch formType {
-            case .yearOfAcquisition:
+            case .acquisitionYear:
                 guard let acquisitionYearCellVM = formCellVM as? TextFieldCellViewModel else {
                     XCTFail("Wrong type")
                     return
@@ -121,6 +121,12 @@ final class AddGameDetailsSectionTests: XCTestCase {
                     return
                 }
                 XCTAssertEqual(notesCellVM.title, L10n.otherDetails)
+            case .isPhysical:
+                guard let isPhysicalCellVM = formCellVM as? SegmentedControlCellViewModel else {
+                    XCTFail("Wrong type")
+                    return
+                }
+                XCTAssertEqual(isPhysicalCellVM.value, MockData.savedGame.isPhysical ? L10n.physical : L10n.digital)
             }
         }
     }

--- a/GameDexTests/AddGame/AddGameDetails/AddGameDetailsViewModelTests.swift
+++ b/GameDexTests/AddGame/AddGameDetails/AddGameDetailsViewModelTests.swift
@@ -36,9 +36,8 @@ final class AddGameDetailsViewModelTests: XCTestCase {
         )
         
         // Then
-        XCTAssertEqual(viewModel.sections.count, 1)
-        XCTAssertEqual(viewModel.numberOfSections(), 1)
-        XCTAssertEqual(viewModel.numberOfItems(in: .zero), 8)
+        XCTAssertEqual(viewModel.sections.count, .zero)
+        XCTAssertEqual(viewModel.numberOfSections(), .zero)
     }
     
     func test_loadData_ThenCallBackIsCalled() {
@@ -243,7 +242,6 @@ final class AddGameDetailsViewModelTests: XCTestCase {
                 userId: .any,
                 game: .any,
                 platform: .any,
-                editingEntry: .value(false),
                 willReturn: nil
             )
         )
@@ -307,7 +305,6 @@ final class AddGameDetailsViewModelTests: XCTestCase {
                 userId: .any,
                 game: .any,
                 platform: .any,
-                editingEntry: .value(false),
                 willReturn: DatabaseError.saveError
             )
         )
@@ -364,7 +361,6 @@ final class AddGameDetailsViewModelTests: XCTestCase {
                 userId: .any,
                 game: .any,
                 platform: .any,
-                editingEntry: .value(false),
                 willReturn: DatabaseError.itemAlreadySaved
             )
         )

--- a/GameDexTests/Common/CellsViewModel/StarRatingCellViewModelTests.swift
+++ b/GameDexTests/Common/CellsViewModel/StarRatingCellViewModelTests.swift
@@ -18,7 +18,7 @@ final class StarRatingCellViewModelTests: XCTestCase {
             title: title,
             formType: GameFormType.rating,
             value: .zero,
-            editDelegate: EditFormDelegateMock()
+            formDelegate: FormDelegateMock()
         )
         
         // Then
@@ -29,12 +29,12 @@ final class StarRatingCellViewModelTests: XCTestCase {
     
     func test_value_GivenValueChanged_ThenShouldCallEditFormDelegate() {
         // Given
-        let delegate = EditFormDelegateMock()
+        let delegate = FormDelegateMock()
         let cellVM = StarRatingCellViewModel(
             title: "title",
             formType: GameFormType.notes,
             value: .zero,
-            editDelegate: delegate
+            formDelegate: delegate
         )
         
         // When

--- a/GameDexTests/Common/CellsViewModel/TextFieldCellViewModelTests.swift
+++ b/GameDexTests/Common/CellsViewModel/TextFieldCellViewModelTests.swift
@@ -20,7 +20,7 @@ final class TextFieldCellViewModelTests: XCTestCase {
             placeholder: placeholder,
             formType: GameFormType.storageArea,
             value: text,
-            editDelegate: EditFormDelegateMock()
+            formDelegate: FormDelegateMock()
         )
         // Then
         XCTAssertEqual(cellVM.placeholder, "Some placeholder")

--- a/GameDexTests/Common/CellsViewModel/TextViewCellViewModelTests.swift
+++ b/GameDexTests/Common/CellsViewModel/TextViewCellViewModelTests.swift
@@ -19,7 +19,7 @@ final class TextViewCellViewModelTests: XCTestCase {
             title: title,
             formType: GameFormType.notes,
             value: text,
-            editDelegate: EditFormDelegateMock()
+            formDelegate: FormDelegateMock()
         )
         
         // Then
@@ -30,12 +30,12 @@ final class TextViewCellViewModelTests: XCTestCase {
     
     func test_value_GivenValueChanged_ThenShouldCallEditFormDelegate() {
         // Given
-        let delegate = EditFormDelegateMock()
+        let delegate = FormDelegateMock()
         let cellVM = TextViewCellViewModel(
             title: "title",
             formType: GameFormType.notes,
             value: "text",
-            editDelegate: delegate
+            formDelegate: delegate
         )
         
         // When

--- a/GameDexTests/Firestore/FirestoreDatabaseTests.swift
+++ b/GameDexTests/Firestore/FirestoreDatabaseTests.swift
@@ -12,7 +12,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getAvailablePlatforms_GivenNoError_ThenShouldReturnPlatforms() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreAPIPlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreAPIPlatformsCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -25,7 +25,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getAvailablePlatforms_GivenReturnDataAttributesError_ThenShouldReturnDatabaseFetchError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreAPIPlatformsIncorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreAPIPlatformsIncorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -38,7 +38,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getAvailablePlatforms_GivenErrorFetchingData_ThenShouldReturnDatabaseFetchError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .failure(DatabaseError.fetchError)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .failure(DatabaseError.fetchError)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -51,7 +51,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getSinglePlatformCollection_GivenNoError_ThenShouldReturnPlatform() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -65,7 +65,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getSinglePlatformCollection_GivenErrorConvertingData_ThenShouldReturnFetchError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesIncorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreGamesIncorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -78,7 +78,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getSinglePlatformCollection_GivenFetchError_ThenShouldReturnFetchError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .failure(DatabaseError.fetchError)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .failure(DatabaseError.fetchError)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -91,7 +91,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getUserCollection_GivenFetchError_ThenShouldReturnDatabaseFetchError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .failure(DatabaseError.fetchError)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .failure(DatabaseError.fetchError)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -104,7 +104,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_getUserCollection_GivenErrorConvertingData_ThenShouldReturnFetchError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesIncorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreGamesIncorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -170,7 +170,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_gameIsInDatabase_GivenNoErrorFetchingDataAndGameIdIsFound_ThenShouldReturnTrue() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -183,7 +183,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_gameIsInDatabase_GivenNoErrorFetchingDataAndGameIdIsNotFound_ThenShouldReturnFalse() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         let newSavedGame = SavedGame(game: Game(title: "title", description: "description", id: "wrongid", platformId: 1, imageUrl: "url", releaseDate: Date.now), acquisitionYear: nil, gameCondition: nil, gameCompleteness: nil, gameRegion: nil, storageArea: nil, rating: 0, notes: nil, lastUpdated: Date.now, isPhysical: true)
         
@@ -197,7 +197,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_gameIsInDatabase_GivenErrorFetchingData_ThenShouldReturnDatabaseError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .failure(DatabaseError.fetchError)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .failure(DatabaseError.fetchError)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -272,72 +272,77 @@ final class FirestoreDatabaseTests: XCTestCase {
         XCTAssertEqual(error, DatabaseError.saveError)
     }
 
-    func test_saveGame_GivenEditingEntryTrueAndNoError_ThenShouldReturnNil() async {
+    func test_replaceGame_GivenNoError_ThenShouldReturnNil() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success([MockData.firestoreGameCorrectData])))
         firestoreSession.given(.setData(path: .any, firestoreData: .any, willReturn: nil))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
-        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.savedGame, platform: MockData.platform, editingEntry: true)
+        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.savedGame, platform: MockData.platform)
         
         // THEN
         XCTAssertNil(error)
     }
     
-    func test_saveGame_GivenEditingEntryFalseAndNoError_ThenShouldReturnNil() async {
+    func test_saveGame_GivenNoError_ThenShouldReturnNil() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
         firestoreSession.given(.setData(path: .any, firestoreData: .any, willReturn: nil))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
-        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.savedGame, platform: MockData.platform, editingEntry: false)
+        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.savedGame, platform: MockData.platform)
         
         // THEN
         XCTAssertNil(error)
     }
     
-    func test_saveGame_GivenEditingEntryFalseAndItemAlreadySaved_ThenShouldReturnDatabaseError() async {
+    func test_saveGame_GivenItemAlreadySaved_ThenShouldReturnDatabaseError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
         firestoreSession.given(.setData(path: .any, firestoreData: .any, willReturn: nil))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
-        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.firestoreGamesResultConverted[0], platform: MockData.platform, editingEntry: false)
+        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.firestoreGamesResultConverted[0], platform: MockData.platform)
         
         // THEN
         XCTAssertEqual(error, DatabaseError.itemAlreadySaved)
     }
     
-    func test_saveGame_GivenEditingEntryTrueAndErrorSavingPlatform_ThenShouldReturnDatabaseError() async {
+    func test_replaceGame_GivenErrorSavingPlatform_ThenShouldReturnDatabaseError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success([MockData.firestoreGameCorrectData])))
         firestoreSession.given(.setData(path: .value(MockData.userPlatformsPath), firestoreData: .any, willReturn: DatabaseError.saveError))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
+        
         // WHEN
-        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.savedGame, platform: MockData.platform, editingEntry: true)
+        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.savedGame, platform: MockData.platform)
         
         // THEN
         XCTAssertEqual(error, DatabaseError.saveError)
     }
     
-    func test_saveGame_GivenEditingEntryTrueAndErrorSavingGames_ThenShouldReturnDatabaseError() async {
+    func test_replaceGame_GivenErrorGameAlreadySaved_ThenShouldReturnDatabaseError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.setData(path: .value(MockData.userPlatformsPath), firestoreData: .any, willReturn: nil))
+//        firestoreSession.given(.setData(path: .value(MockData.userPlatformsPath), firestoreData: .any, willReturn: nil))
         firestoreSession.given(.setData(path: .value(MockData.userGamesPath), firestoreData: .any, willReturn: DatabaseError.saveError))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
-        let error = await firestoreDatabase.saveGame(userId: "userId", game: MockData.savedGame, platform: MockData.platform, editingEntry: true)
+        let error = await firestoreDatabase.replaceGame(userId: "userId", newGame: MockData.savedGame, oldGame: MockData.oldSavedGame, platform: MockData.platform)
         
         // THEN
-        XCTAssertEqual(error, DatabaseError.saveError)
+        XCTAssertEqual(error, DatabaseError.itemAlreadySaved)
     }
     
     func test_saveGames_GivenNoError_ThenShouldReturnNil() async {
@@ -468,7 +473,7 @@ final class FirestoreDatabaseTests: XCTestCase {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
         firestoreSession.given(.deleteData(path: .any, directory: .any, willReturn: nil))
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success([MockData.firestoreGameCorrectData])))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -481,6 +486,7 @@ final class FirestoreDatabaseTests: XCTestCase {
     func test_removeGame_GivenErrorDeletingGame_ThenShouldReturnDatabaseError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success([MockData.firestoreGameCorrectData])))
         firestoreSession.given(.deleteData(path: .any, directory: .any, willReturn: DatabaseError.removeError))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
@@ -495,7 +501,7 @@ final class FirestoreDatabaseTests: XCTestCase {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
         firestoreSession.given(.deleteData(path: .value(MockData.userGamesPath), directory: .any, willReturn: nil))
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .failure(DatabaseError.fetchError)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .failure(DatabaseError.fetchError)))
         
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
@@ -503,14 +509,14 @@ final class FirestoreDatabaseTests: XCTestCase {
         let error = await firestoreDatabase.removeGame(userId: "userId", platform: MockData.platform, savedGame: MockData.savedGame)
         
         // THEN
-        XCTAssertEqual(error, DatabaseError.removeError)
+        XCTAssertEqual(error, DatabaseError.fetchError)
     }
     
     func test_removeGame_GivenErrorDeletingPlatformWithNoGame_ThenShouldReturnDatabaseError() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
         firestoreSession.given(.deleteData(path: .value(MockData.userGamesPath), directory: .any, willReturn: nil))
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreEmptyData)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .success(MockData.firestoreEmptyData)))
         firestoreSession.given(.deleteData(path: .value(MockData.userPlatformsPath), directory: .any, willReturn: DatabaseError.removeError))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
@@ -518,30 +524,15 @@ final class FirestoreDatabaseTests: XCTestCase {
         let error = await firestoreDatabase.removeGame(userId: "userId", platform: MockData.platform, savedGame: MockData.savedGame)
         
         // THEN
-        XCTAssertEqual(error, DatabaseError.removeError)
+        XCTAssertEqual(error, DatabaseError.fetchError)
     }
     
-    func test_removeGame_GivenNoErrorDeletingPlatformWithNoGame_ThenShouldReturnNil() async {
-        // GIVEN
-        let firestoreSession = FirestoreSessionMock()
-        firestoreSession.given(.deleteData(path: .value(MockData.userGamesPath), directory: .any, willReturn: nil))
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .success(MockData.firestoreEmptyData)))
-        firestoreSession.given(.deleteData(path: .value(MockData.userPlatformsPath), directory: .any, willReturn: nil))
-        let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
-        
-        // WHEN
-        let error = await firestoreDatabase.removeGame(userId: "userId", platform: MockData.platform, savedGame: MockData.savedGame)
-        
-        // THEN
-        XCTAssertNil(error)
-    }
-   
     func test_removeUser_GivenNoError_ThenShouldReturnNil() async {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
         firestoreSession.given(.deleteData(path: .any, directory: .any, willReturn: nil))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), willReturn: .success(MockData.firestoreGamesCorrectData)))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), willReturn: .success(MockData.firestorePlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), condition: .any, willReturn: .success(MockData.firestorePlatformsCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -555,7 +546,7 @@ final class FirestoreDatabaseTests: XCTestCase {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
         firestoreSession.given(.deleteData(path: .any, directory: .any, willReturn: nil))
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .failure(DatabaseError.fetchError)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .failure(DatabaseError.fetchError)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -569,8 +560,8 @@ final class FirestoreDatabaseTests: XCTestCase {
         // GIVEN
         let firestoreSession = FirestoreSessionMock()
         firestoreSession.given(.deleteData(path: .value(MockData.userGamesPath), directory: .any, willReturn: DatabaseError.removeError))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), willReturn: .success(MockData.firestoreGamesCorrectData)))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), willReturn: .success(MockData.firestorePlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), condition: .any, willReturn: .success(MockData.firestorePlatformsCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -585,8 +576,8 @@ final class FirestoreDatabaseTests: XCTestCase {
         let firestoreSession = FirestoreSessionMock()
         firestoreSession.given(.deleteData(path: .value(MockData.userGamesPath), directory: .any, willReturn: nil))
         firestoreSession.given(.deleteData(path: .value(MockData.userPlatformsPath), directory: .any, willReturn: DatabaseError.removeError))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), willReturn: .success(MockData.firestoreGamesCorrectData)))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), willReturn: .success(MockData.firestorePlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), condition: .any, willReturn: .success(MockData.firestorePlatformsCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -602,8 +593,8 @@ final class FirestoreDatabaseTests: XCTestCase {
         firestoreSession.given(.deleteData(path: .value(MockData.userGamesPath), directory: .any, willReturn: nil))
         firestoreSession.given(.deleteData(path: .value(MockData.userPlatformsPath), directory: .any, willReturn: nil))
         firestoreSession.given(.deleteData(path: .value(MockData.userPath), directory: .any, willReturn: DatabaseError.removeError))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), willReturn: .success(MockData.firestoreGamesCorrectData)))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), willReturn: .success(MockData.firestorePlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), condition: .any, willReturn: .success(MockData.firestorePlatformsCorrectData)))
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
         
         // WHEN
@@ -620,8 +611,8 @@ final class FirestoreDatabaseTests: XCTestCase {
         localDatabase.given(.add(newEntity: .any, platform: .any, willReturn: nil))
         let firestoreSession = FirestoreSessionMock()
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
-        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), willReturn: .success(MockData.firestoreGamesCorrectData)))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), willReturn: .success(MockData.firestorePlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), condition: .any, willReturn: .success(MockData.firestorePlatformsCorrectData)))
         
         // WHEN
         let error = await firestoreDatabase.syncLocalAndCloudDatabases(userId: "userId", localDatabase: localDatabase)
@@ -637,8 +628,8 @@ final class FirestoreDatabaseTests: XCTestCase {
         localDatabase.given(.add(newEntity: .any, platform: .any, willReturn: DatabaseError.saveError))
         let firestoreSession = FirestoreSessionMock()
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
-        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), willReturn: .success(MockData.firestoreGamesCorrectData)))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), willReturn: .success(MockData.firestorePlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), condition: .any, willReturn: .success(MockData.firestorePlatformsCorrectData)))
         
         // WHEN
         let error = await firestoreDatabase.syncLocalAndCloudDatabases(userId: "userId", localDatabase: localDatabase)
@@ -653,8 +644,8 @@ final class FirestoreDatabaseTests: XCTestCase {
         localDatabase.given(.removeAll(willReturn: DatabaseError.removeError))
         let firestoreSession = FirestoreSessionMock()
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
-        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), willReturn: .success(MockData.firestoreGamesCorrectData)))
-        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), willReturn: .success(MockData.firestorePlatformsCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userGamesPath), condition: .any, willReturn: .success(MockData.firestoreGamesCorrectData)))
+        firestoreSession.given(.getData(mainPath: .value(MockData.userPlatformsPath), condition: .any, willReturn: .success(MockData.firestorePlatformsCorrectData)))
         
         // WHEN
         let error = await firestoreDatabase.syncLocalAndCloudDatabases(userId: "userId", localDatabase: localDatabase)
@@ -668,7 +659,7 @@ final class FirestoreDatabaseTests: XCTestCase {
         let localDatabase = LocalDatabaseMock()
         let firestoreSession = FirestoreSessionMock()
         let firestoreDatabase = FirestoreDatabase(firestoreSession: firestoreSession)
-        firestoreSession.given(.getData(mainPath: .any, willReturn: .failure(DatabaseError.fetchError)))
+        firestoreSession.given(.getData(mainPath: .any, condition: .any, willReturn: .failure(DatabaseError.fetchError)))
         
         // WHEN
         let error = await firestoreDatabase.syncLocalAndCloudDatabases(userId: "userId", localDatabase: localDatabase)

--- a/GameDexTests/Mock/Mock.generated.swift
+++ b/GameDexTests/Mock/Mock.generated.swift
@@ -2166,6 +2166,20 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 		return __value
     }
 
+    open func getGameUUID(userId: String, newGame: SavedGame?, oldGame: SavedGame) -> Result<String?, DatabaseError> {
+        addInvocation(.m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(Parameter<String>.value(`userId`), Parameter<SavedGame?>.value(`newGame`), Parameter<SavedGame>.value(`oldGame`)))
+		let perform = methodPerformValue(.m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(Parameter<String>.value(`userId`), Parameter<SavedGame?>.value(`newGame`), Parameter<SavedGame>.value(`oldGame`))) as? (String, SavedGame?, SavedGame) -> Void
+		perform?(`userId`, `newGame`, `oldGame`)
+		var __value: Result<String?, DatabaseError>
+		do {
+		    __value = try methodReturnValue(.m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(Parameter<String>.value(`userId`), Parameter<SavedGame?>.value(`newGame`), Parameter<SavedGame>.value(`oldGame`))).casted()
+		} catch {
+			onFatalFailure("Stub return value not specified for getGameUUID(userId: String, newGame: SavedGame?, oldGame: SavedGame). Use given")
+			Failure("Stub return value not specified for getGameUUID(userId: String, newGame: SavedGame?, oldGame: SavedGame). Use given")
+		}
+		return __value
+    }
+
     open func saveUser(userId: String, userEmail: String) -> DatabaseError? {
         addInvocation(.m_saveUser__userId_userIduserEmail_userEmail(Parameter<String>.value(`userId`), Parameter<String>.value(`userEmail`)))
 		let perform = methodPerformValue(.m_saveUser__userId_userIduserEmail_userEmail(Parameter<String>.value(`userId`), Parameter<String>.value(`userEmail`))) as? (String, String) -> Void
@@ -2205,13 +2219,13 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 		return __value
     }
 
-    open func saveGame(userId: String, game: SavedGame, platform: Platform, editingEntry: Bool) -> DatabaseError? {
-        addInvocation(.m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`game`), Parameter<Platform>.value(`platform`), Parameter<Bool>.value(`editingEntry`)))
-		let perform = methodPerformValue(.m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`game`), Parameter<Platform>.value(`platform`), Parameter<Bool>.value(`editingEntry`))) as? (String, SavedGame, Platform, Bool) -> Void
-		perform?(`userId`, `game`, `platform`, `editingEntry`)
+    open func saveGame(userId: String, game: SavedGame, platform: Platform) -> DatabaseError? {
+        addInvocation(.m_saveGame__userId_userIdgame_gameplatform_platform(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`game`), Parameter<Platform>.value(`platform`)))
+		let perform = methodPerformValue(.m_saveGame__userId_userIdgame_gameplatform_platform(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`game`), Parameter<Platform>.value(`platform`))) as? (String, SavedGame, Platform) -> Void
+		perform?(`userId`, `game`, `platform`)
 		var __value: DatabaseError? = nil
 		do {
-		    __value = try methodReturnValue(.m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`game`), Parameter<Platform>.value(`platform`), Parameter<Bool>.value(`editingEntry`))).casted()
+		    __value = try methodReturnValue(.m_saveGame__userId_userIdgame_gameplatform_platform(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`game`), Parameter<Platform>.value(`platform`))).casted()
 		} catch {
 			// do nothing
 		}
@@ -2240,6 +2254,33 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 		    __value = try methodReturnValue(.m_saveCollection__userId_userIdlocalDatabase_localDatabase(Parameter<String>.value(`userId`), Parameter<LocalDatabase>.value(`localDatabase`))).casted()
 		} catch {
 			// do nothing
+		}
+		return __value
+    }
+
+    open func replaceGame(userId: String, newGame: SavedGame, oldGame: SavedGame, platform: Platform) -> DatabaseError? {
+        addInvocation(.m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`newGame`), Parameter<SavedGame>.value(`oldGame`), Parameter<Platform>.value(`platform`)))
+		let perform = methodPerformValue(.m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`newGame`), Parameter<SavedGame>.value(`oldGame`), Parameter<Platform>.value(`platform`))) as? (String, SavedGame, SavedGame, Platform) -> Void
+		perform?(`userId`, `newGame`, `oldGame`, `platform`)
+		var __value: DatabaseError? = nil
+		do {
+		    __value = try methodReturnValue(.m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(Parameter<String>.value(`userId`), Parameter<SavedGame>.value(`newGame`), Parameter<SavedGame>.value(`oldGame`), Parameter<Platform>.value(`platform`))).casted()
+		} catch {
+			// do nothing
+		}
+		return __value
+    }
+
+    open func isSameGame(savedGame: SavedGame, firestoreGameData: FirestoreData) -> Bool {
+        addInvocation(.m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(Parameter<SavedGame>.value(`savedGame`), Parameter<FirestoreData>.value(`firestoreGameData`)))
+		let perform = methodPerformValue(.m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(Parameter<SavedGame>.value(`savedGame`), Parameter<FirestoreData>.value(`firestoreGameData`))) as? (SavedGame, FirestoreData) -> Void
+		perform?(`savedGame`, `firestoreGameData`)
+		var __value: Bool
+		do {
+		    __value = try methodReturnValue(.m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(Parameter<SavedGame>.value(`savedGame`), Parameter<FirestoreData>.value(`firestoreGameData`))).casted()
+		} catch {
+			onFatalFailure("Stub return value not specified for isSameGame(savedGame: SavedGame, firestoreGameData: FirestoreData). Use given")
+			Failure("Stub return value not specified for isSameGame(savedGame: SavedGame, firestoreGameData: FirestoreData). Use given")
 		}
 		return __value
     }
@@ -2329,12 +2370,15 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
         case m_getSinglePlatformCollection__userId_userIdplatform_platform(Parameter<String>, Parameter<Platform>)
         case m_getUserCollection__userId_userId(Parameter<String>)
         case m_getAvailablePlatforms
+        case m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(Parameter<String>, Parameter<SavedGame?>, Parameter<SavedGame>)
         case m_saveUser__userId_userIduserEmail_userEmail(Parameter<String>, Parameter<String>)
         case m_saveUserEmail__userId_userIduserEmail_userEmail(Parameter<String>, Parameter<String>)
         case m_saveGames__userId_userIdplatform_platform(Parameter<String>, Parameter<Platform>)
-        case m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(Parameter<String>, Parameter<SavedGame>, Parameter<Platform>, Parameter<Bool>)
+        case m_saveGame__userId_userIdgame_gameplatform_platform(Parameter<String>, Parameter<SavedGame>, Parameter<Platform>)
         case m_savePlatform__userId_userIdplatform_platform(Parameter<String>, Parameter<Platform>)
         case m_saveCollection__userId_userIdlocalDatabase_localDatabase(Parameter<String>, Parameter<LocalDatabase>)
+        case m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(Parameter<String>, Parameter<SavedGame>, Parameter<SavedGame>, Parameter<Platform>)
+        case m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(Parameter<SavedGame>, Parameter<FirestoreData>)
         case m_gameIsInDatabase__userId_userIdsavedGame_savedGame(Parameter<String>, Parameter<SavedGame>)
         case m_removeGame__userId_userIdplatform_platformsavedGame_savedGame(Parameter<String>, Parameter<Platform>, Parameter<SavedGame>)
         case m_removeUser__userId_userId(Parameter<String>)
@@ -2359,6 +2403,13 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 
             case (.m_getAvailablePlatforms, .m_getAvailablePlatforms): return .match
 
+            case (.m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(let lhsUserid, let lhsNewgame, let lhsOldgame), .m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(let rhsUserid, let rhsNewgame, let rhsOldgame)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsUserid, rhs: rhsUserid, with: matcher), lhsUserid, rhsUserid, "userId"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsNewgame, rhs: rhsNewgame, with: matcher), lhsNewgame, rhsNewgame, "newGame"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsOldgame, rhs: rhsOldgame, with: matcher), lhsOldgame, rhsOldgame, "oldGame"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_saveUser__userId_userIduserEmail_userEmail(let lhsUserid, let lhsUseremail), .m_saveUser__userId_userIduserEmail_userEmail(let rhsUserid, let rhsUseremail)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsUserid, rhs: rhsUserid, with: matcher), lhsUserid, rhsUserid, "userId"))
@@ -2377,12 +2428,11 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPlatform, rhs: rhsPlatform, with: matcher), lhsPlatform, rhsPlatform, "platform"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(let lhsUserid, let lhsGame, let lhsPlatform, let lhsEditingentry), .m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(let rhsUserid, let rhsGame, let rhsPlatform, let rhsEditingentry)):
+            case (.m_saveGame__userId_userIdgame_gameplatform_platform(let lhsUserid, let lhsGame, let lhsPlatform), .m_saveGame__userId_userIdgame_gameplatform_platform(let rhsUserid, let rhsGame, let rhsPlatform)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsUserid, rhs: rhsUserid, with: matcher), lhsUserid, rhsUserid, "userId"))
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsGame, rhs: rhsGame, with: matcher), lhsGame, rhsGame, "game"))
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPlatform, rhs: rhsPlatform, with: matcher), lhsPlatform, rhsPlatform, "platform"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEditingentry, rhs: rhsEditingentry, with: matcher), lhsEditingentry, rhsEditingentry, "editingEntry"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_savePlatform__userId_userIdplatform_platform(let lhsUserid, let lhsPlatform), .m_savePlatform__userId_userIdplatform_platform(let rhsUserid, let rhsPlatform)):
@@ -2395,6 +2445,20 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsUserid, rhs: rhsUserid, with: matcher), lhsUserid, rhsUserid, "userId"))
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLocaldatabase, rhs: rhsLocaldatabase, with: matcher), lhsLocaldatabase, rhsLocaldatabase, "localDatabase"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(let lhsUserid, let lhsNewgame, let lhsOldgame, let lhsPlatform), .m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(let rhsUserid, let rhsNewgame, let rhsOldgame, let rhsPlatform)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsUserid, rhs: rhsUserid, with: matcher), lhsUserid, rhsUserid, "userId"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsNewgame, rhs: rhsNewgame, with: matcher), lhsNewgame, rhsNewgame, "newGame"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsOldgame, rhs: rhsOldgame, with: matcher), lhsOldgame, rhsOldgame, "oldGame"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPlatform, rhs: rhsPlatform, with: matcher), lhsPlatform, rhsPlatform, "platform"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(let lhsSavedgame, let lhsFirestoregamedata), .m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(let rhsSavedgame, let rhsFirestoregamedata)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSavedgame, rhs: rhsSavedgame, with: matcher), lhsSavedgame, rhsSavedgame, "savedGame"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsFirestoregamedata, rhs: rhsFirestoregamedata, with: matcher), lhsFirestoregamedata, rhsFirestoregamedata, "firestoreGameData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_gameIsInDatabase__userId_userIdsavedGame_savedGame(let lhsUserid, let lhsSavedgame), .m_gameIsInDatabase__userId_userIdsavedGame_savedGame(let rhsUserid, let rhsSavedgame)):
@@ -2442,12 +2506,15 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
             case let .m_getSinglePlatformCollection__userId_userIdplatform_platform(p0, p1): return p0.intValue + p1.intValue
             case let .m_getUserCollection__userId_userId(p0): return p0.intValue
             case .m_getAvailablePlatforms: return 0
+            case let .m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_saveUser__userId_userIduserEmail_userEmail(p0, p1): return p0.intValue + p1.intValue
             case let .m_saveUserEmail__userId_userIduserEmail_userEmail(p0, p1): return p0.intValue + p1.intValue
             case let .m_saveGames__userId_userIdplatform_platform(p0, p1): return p0.intValue + p1.intValue
-            case let .m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_saveGame__userId_userIdgame_gameplatform_platform(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_savePlatform__userId_userIdplatform_platform(p0, p1): return p0.intValue + p1.intValue
             case let .m_saveCollection__userId_userIdlocalDatabase_localDatabase(p0, p1): return p0.intValue + p1.intValue
+            case let .m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(p0, p1): return p0.intValue + p1.intValue
             case let .m_gameIsInDatabase__userId_userIdsavedGame_savedGame(p0, p1): return p0.intValue + p1.intValue
             case let .m_removeGame__userId_userIdplatform_platformsavedGame_savedGame(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_removeUser__userId_userId(p0): return p0.intValue
@@ -2462,12 +2529,15 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
             case .m_getSinglePlatformCollection__userId_userIdplatform_platform: return ".getSinglePlatformCollection(userId:platform:)"
             case .m_getUserCollection__userId_userId: return ".getUserCollection(userId:)"
             case .m_getAvailablePlatforms: return ".getAvailablePlatforms()"
+            case .m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame: return ".getGameUUID(userId:newGame:oldGame:)"
             case .m_saveUser__userId_userIduserEmail_userEmail: return ".saveUser(userId:userEmail:)"
             case .m_saveUserEmail__userId_userIduserEmail_userEmail: return ".saveUserEmail(userId:userEmail:)"
             case .m_saveGames__userId_userIdplatform_platform: return ".saveGames(userId:platform:)"
-            case .m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry: return ".saveGame(userId:game:platform:editingEntry:)"
+            case .m_saveGame__userId_userIdgame_gameplatform_platform: return ".saveGame(userId:game:platform:)"
             case .m_savePlatform__userId_userIdplatform_platform: return ".savePlatform(userId:platform:)"
             case .m_saveCollection__userId_userIdlocalDatabase_localDatabase: return ".saveCollection(userId:localDatabase:)"
+            case .m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform: return ".replaceGame(userId:newGame:oldGame:platform:)"
+            case .m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData: return ".isSameGame(savedGame:firestoreGameData:)"
             case .m_gameIsInDatabase__userId_userIdsavedGame_savedGame: return ".gameIsInDatabase(userId:savedGame:)"
             case .m_removeGame__userId_userIdplatform_platformsavedGame_savedGame: return ".removeGame(userId:platform:savedGame:)"
             case .m_removeUser__userId_userId: return ".removeUser(userId:)"
@@ -2499,6 +2569,9 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
         public static func getAvailablePlatforms(willReturn: Result<[Platform], DatabaseError>...) -> MethodStub {
             return Given(method: .m_getAvailablePlatforms, products: willReturn.map({ StubProduct.return($0 as Any) }))
         }
+        public static func getGameUUID(userId: Parameter<String>, newGame: Parameter<SavedGame?>, oldGame: Parameter<SavedGame>, willReturn: Result<String?, DatabaseError>...) -> MethodStub {
+            return Given(method: .m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(`userId`, `newGame`, `oldGame`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
         public static func saveUser(userId: Parameter<String>, userEmail: Parameter<String>, willReturn: DatabaseError?...) -> MethodStub {
             return Given(method: .m_saveUser__userId_userIduserEmail_userEmail(`userId`, `userEmail`), products: willReturn.map({ StubProduct.return($0 as Any) }))
         }
@@ -2508,14 +2581,20 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
         public static func saveGames(userId: Parameter<String>, platform: Parameter<Platform>, willReturn: DatabaseError?...) -> MethodStub {
             return Given(method: .m_saveGames__userId_userIdplatform_platform(`userId`, `platform`), products: willReturn.map({ StubProduct.return($0 as Any) }))
         }
-        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>, editingEntry: Parameter<Bool>, willReturn: DatabaseError?...) -> MethodStub {
-            return Given(method: .m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(`userId`, `game`, `platform`, `editingEntry`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>, willReturn: DatabaseError?...) -> MethodStub {
+            return Given(method: .m_saveGame__userId_userIdgame_gameplatform_platform(`userId`, `game`, `platform`), products: willReturn.map({ StubProduct.return($0 as Any) }))
         }
         public static func savePlatform(userId: Parameter<String>, platform: Parameter<Platform>, willReturn: DatabaseError?...) -> MethodStub {
             return Given(method: .m_savePlatform__userId_userIdplatform_platform(`userId`, `platform`), products: willReturn.map({ StubProduct.return($0 as Any) }))
         }
         public static func saveCollection(userId: Parameter<String>, localDatabase: Parameter<LocalDatabase>, willReturn: DatabaseError?...) -> MethodStub {
             return Given(method: .m_saveCollection__userId_userIdlocalDatabase_localDatabase(`userId`, `localDatabase`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
+        public static func replaceGame(userId: Parameter<String>, newGame: Parameter<SavedGame>, oldGame: Parameter<SavedGame>, platform: Parameter<Platform>, willReturn: DatabaseError?...) -> MethodStub {
+            return Given(method: .m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(`userId`, `newGame`, `oldGame`, `platform`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
+        public static func isSameGame(savedGame: Parameter<SavedGame>, firestoreGameData: Parameter<FirestoreData>, willReturn: Bool...) -> MethodStub {
+            return Given(method: .m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(`savedGame`, `firestoreGameData`), products: willReturn.map({ StubProduct.return($0 as Any) }))
         }
         public static func gameIsInDatabase(userId: Parameter<String>, savedGame: Parameter<SavedGame>, willReturn: Result<Bool, DatabaseError>...) -> MethodStub {
             return Given(method: .m_gameIsInDatabase__userId_userIdsavedGame_savedGame(`userId`, `savedGame`), products: willReturn.map({ StubProduct.return($0 as Any) }))
@@ -2563,6 +2642,13 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 			willProduce(stubber)
 			return given
         }
+        public static func getGameUUID(userId: Parameter<String>, newGame: Parameter<SavedGame?>, oldGame: Parameter<SavedGame>, willProduce: (Stubber<Result<String?, DatabaseError>>) -> Void) -> MethodStub {
+            let willReturn: [Result<String?, DatabaseError>] = []
+			let given: Given = { return Given(method: .m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(`userId`, `newGame`, `oldGame`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let stubber = given.stub(for: (Result<String?, DatabaseError>).self)
+			willProduce(stubber)
+			return given
+        }
         public static func saveUser(userId: Parameter<String>, userEmail: Parameter<String>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
             let willReturn: [DatabaseError?] = []
 			let given: Given = { return Given(method: .m_saveUser__userId_userIduserEmail_userEmail(`userId`, `userEmail`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
@@ -2584,9 +2670,9 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
 			willProduce(stubber)
 			return given
         }
-        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>, editingEntry: Parameter<Bool>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
+        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
             let willReturn: [DatabaseError?] = []
-			let given: Given = { return Given(method: .m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(`userId`, `game`, `platform`, `editingEntry`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let given: Given = { return Given(method: .m_saveGame__userId_userIdgame_gameplatform_platform(`userId`, `game`, `platform`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
 			let stubber = given.stub(for: (DatabaseError?).self)
 			willProduce(stubber)
 			return given
@@ -2602,6 +2688,20 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
             let willReturn: [DatabaseError?] = []
 			let given: Given = { return Given(method: .m_saveCollection__userId_userIdlocalDatabase_localDatabase(`userId`, `localDatabase`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
 			let stubber = given.stub(for: (DatabaseError?).self)
+			willProduce(stubber)
+			return given
+        }
+        public static func replaceGame(userId: Parameter<String>, newGame: Parameter<SavedGame>, oldGame: Parameter<SavedGame>, platform: Parameter<Platform>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
+            let willReturn: [DatabaseError?] = []
+			let given: Given = { return Given(method: .m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(`userId`, `newGame`, `oldGame`, `platform`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let stubber = given.stub(for: (DatabaseError?).self)
+			willProduce(stubber)
+			return given
+        }
+        public static func isSameGame(savedGame: Parameter<SavedGame>, firestoreGameData: Parameter<FirestoreData>, willProduce: (Stubber<Bool>) -> Void) -> MethodStub {
+            let willReturn: [Bool] = []
+			let given: Given = { return Given(method: .m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(`savedGame`, `firestoreGameData`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let stubber = given.stub(for: (Bool).self)
 			willProduce(stubber)
 			return given
         }
@@ -2656,12 +2756,15 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
         public static func getSinglePlatformCollection(userId: Parameter<String>, platform: Parameter<Platform>) -> Verify { return Verify(method: .m_getSinglePlatformCollection__userId_userIdplatform_platform(`userId`, `platform`))}
         public static func getUserCollection(userId: Parameter<String>) -> Verify { return Verify(method: .m_getUserCollection__userId_userId(`userId`))}
         public static func getAvailablePlatforms() -> Verify { return Verify(method: .m_getAvailablePlatforms)}
+        public static func getGameUUID(userId: Parameter<String>, newGame: Parameter<SavedGame?>, oldGame: Parameter<SavedGame>) -> Verify { return Verify(method: .m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(`userId`, `newGame`, `oldGame`))}
         public static func saveUser(userId: Parameter<String>, userEmail: Parameter<String>) -> Verify { return Verify(method: .m_saveUser__userId_userIduserEmail_userEmail(`userId`, `userEmail`))}
         public static func saveUserEmail(userId: Parameter<String>, userEmail: Parameter<String>) -> Verify { return Verify(method: .m_saveUserEmail__userId_userIduserEmail_userEmail(`userId`, `userEmail`))}
         public static func saveGames(userId: Parameter<String>, platform: Parameter<Platform>) -> Verify { return Verify(method: .m_saveGames__userId_userIdplatform_platform(`userId`, `platform`))}
-        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>, editingEntry: Parameter<Bool>) -> Verify { return Verify(method: .m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(`userId`, `game`, `platform`, `editingEntry`))}
+        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>) -> Verify { return Verify(method: .m_saveGame__userId_userIdgame_gameplatform_platform(`userId`, `game`, `platform`))}
         public static func savePlatform(userId: Parameter<String>, platform: Parameter<Platform>) -> Verify { return Verify(method: .m_savePlatform__userId_userIdplatform_platform(`userId`, `platform`))}
         public static func saveCollection(userId: Parameter<String>, localDatabase: Parameter<LocalDatabase>) -> Verify { return Verify(method: .m_saveCollection__userId_userIdlocalDatabase_localDatabase(`userId`, `localDatabase`))}
+        public static func replaceGame(userId: Parameter<String>, newGame: Parameter<SavedGame>, oldGame: Parameter<SavedGame>, platform: Parameter<Platform>) -> Verify { return Verify(method: .m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(`userId`, `newGame`, `oldGame`, `platform`))}
+        public static func isSameGame(savedGame: Parameter<SavedGame>, firestoreGameData: Parameter<FirestoreData>) -> Verify { return Verify(method: .m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(`savedGame`, `firestoreGameData`))}
         public static func gameIsInDatabase(userId: Parameter<String>, savedGame: Parameter<SavedGame>) -> Verify { return Verify(method: .m_gameIsInDatabase__userId_userIdsavedGame_savedGame(`userId`, `savedGame`))}
         public static func removeGame(userId: Parameter<String>, platform: Parameter<Platform>, savedGame: Parameter<SavedGame>) -> Verify { return Verify(method: .m_removeGame__userId_userIdplatform_platformsavedGame_savedGame(`userId`, `platform`, `savedGame`))}
         public static func removeUser(userId: Parameter<String>) -> Verify { return Verify(method: .m_removeUser__userId_userId(`userId`))}
@@ -2686,6 +2789,9 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
         public static func getAvailablePlatforms(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_getAvailablePlatforms, performs: perform)
         }
+        public static func getGameUUID(userId: Parameter<String>, newGame: Parameter<SavedGame?>, oldGame: Parameter<SavedGame>, perform: @escaping (String, SavedGame?, SavedGame) -> Void) -> Perform {
+            return Perform(method: .m_getGameUUID__userId_userIdnewGame_newGameoldGame_oldGame(`userId`, `newGame`, `oldGame`), performs: perform)
+        }
         public static func saveUser(userId: Parameter<String>, userEmail: Parameter<String>, perform: @escaping (String, String) -> Void) -> Perform {
             return Perform(method: .m_saveUser__userId_userIduserEmail_userEmail(`userId`, `userEmail`), performs: perform)
         }
@@ -2695,14 +2801,20 @@ open class CloudDatabaseMock: CloudDatabase, Mock {
         public static func saveGames(userId: Parameter<String>, platform: Parameter<Platform>, perform: @escaping (String, Platform) -> Void) -> Perform {
             return Perform(method: .m_saveGames__userId_userIdplatform_platform(`userId`, `platform`), performs: perform)
         }
-        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>, editingEntry: Parameter<Bool>, perform: @escaping (String, SavedGame, Platform, Bool) -> Void) -> Perform {
-            return Perform(method: .m_saveGame__userId_userIdgame_gameplatform_platformeditingEntry_editingEntry(`userId`, `game`, `platform`, `editingEntry`), performs: perform)
+        public static func saveGame(userId: Parameter<String>, game: Parameter<SavedGame>, platform: Parameter<Platform>, perform: @escaping (String, SavedGame, Platform) -> Void) -> Perform {
+            return Perform(method: .m_saveGame__userId_userIdgame_gameplatform_platform(`userId`, `game`, `platform`), performs: perform)
         }
         public static func savePlatform(userId: Parameter<String>, platform: Parameter<Platform>, perform: @escaping (String, Platform) -> Void) -> Perform {
             return Perform(method: .m_savePlatform__userId_userIdplatform_platform(`userId`, `platform`), performs: perform)
         }
         public static func saveCollection(userId: Parameter<String>, localDatabase: Parameter<LocalDatabase>, perform: @escaping (String, LocalDatabase) -> Void) -> Perform {
             return Perform(method: .m_saveCollection__userId_userIdlocalDatabase_localDatabase(`userId`, `localDatabase`), performs: perform)
+        }
+        public static func replaceGame(userId: Parameter<String>, newGame: Parameter<SavedGame>, oldGame: Parameter<SavedGame>, platform: Parameter<Platform>, perform: @escaping (String, SavedGame, SavedGame, Platform) -> Void) -> Perform {
+            return Perform(method: .m_replaceGame__userId_userIdnewGame_newGameoldGame_oldGameplatform_platform(`userId`, `newGame`, `oldGame`, `platform`), performs: perform)
+        }
+        public static func isSameGame(savedGame: Parameter<SavedGame>, firestoreGameData: Parameter<FirestoreData>, perform: @escaping (SavedGame, FirestoreData) -> Void) -> Perform {
+            return Perform(method: .m_isSameGame__savedGame_savedGamefirestoreGameData_firestoreGameData(`savedGame`, `firestoreGameData`), performs: perform)
         }
         public static func gameIsInDatabase(userId: Parameter<String>, savedGame: Parameter<SavedGame>, perform: @escaping (String, SavedGame) -> Void) -> Perform {
             return Perform(method: .m_gameIsInDatabase__userId_userIdsavedGame_savedGame(`userId`, `savedGame`), performs: perform)
@@ -3239,9 +3351,9 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
     }
 }
 
-// MARK: - EditFormDelegate
+// MARK: - FirestoreSession
 
-open class EditFormDelegateMock: EditFormDelegate, Mock {
+open class FirestoreSessionMock: FirestoreSession, Mock {
     public init(sequencing sequencingPolicy: SequencingPolicy = .lastWrittenResolvedFirst, stubbing stubbingPolicy: StubbingPolicy = .wrap, file: StaticString = #file, line: UInt = #line) {
         SwiftyMockyTestObserver.setup()
         self.sequencingPolicy = sequencingPolicy
@@ -3283,30 +3395,110 @@ open class EditFormDelegateMock: EditFormDelegate, Mock {
 
 
 
-    open func enableSaveButtonIfNeeded() {
-        addInvocation(.m_enableSaveButtonIfNeeded)
-		let perform = methodPerformValue(.m_enableSaveButtonIfNeeded) as? () -> Void
-		perform?()
+    open func getData(mainPath: String, condition: FirestoreQuery?) -> Result<[FirestoreData], DatabaseError> {
+        addInvocation(.m_getData__mainPath_mainPathcondition_condition(Parameter<String>.value(`mainPath`), Parameter<FirestoreQuery?>.value(`condition`)))
+		let perform = methodPerformValue(.m_getData__mainPath_mainPathcondition_condition(Parameter<String>.value(`mainPath`), Parameter<FirestoreQuery?>.value(`condition`))) as? (String, FirestoreQuery?) -> Void
+		perform?(`mainPath`, `condition`)
+		var __value: Result<[FirestoreData], DatabaseError>
+		do {
+		    __value = try methodReturnValue(.m_getData__mainPath_mainPathcondition_condition(Parameter<String>.value(`mainPath`), Parameter<FirestoreQuery?>.value(`condition`))).casted()
+		} catch {
+			onFatalFailure("Stub return value not specified for getData(mainPath: String, condition: FirestoreQuery?). Use given")
+			Failure("Stub return value not specified for getData(mainPath: String, condition: FirestoreQuery?). Use given")
+		}
+		return __value
+    }
+
+    open func getSingleData(path: String, directory: String) -> Result<FirestoreData, DatabaseError> {
+        addInvocation(.m_getSingleData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`)))
+		let perform = methodPerformValue(.m_getSingleData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))) as? (String, String) -> Void
+		perform?(`path`, `directory`)
+		var __value: Result<FirestoreData, DatabaseError>
+		do {
+		    __value = try methodReturnValue(.m_getSingleData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))).casted()
+		} catch {
+			onFatalFailure("Stub return value not specified for getSingleData(path: String, directory: String). Use given")
+			Failure("Stub return value not specified for getSingleData(path: String, directory: String). Use given")
+		}
+		return __value
+    }
+
+    open func setData(path: String, firestoreData: FirestoreData) -> DatabaseError? {
+        addInvocation(.m_setData__path_pathfirestoreData_firestoreData(Parameter<String>.value(`path`), Parameter<FirestoreData>.value(`firestoreData`)))
+		let perform = methodPerformValue(.m_setData__path_pathfirestoreData_firestoreData(Parameter<String>.value(`path`), Parameter<FirestoreData>.value(`firestoreData`))) as? (String, FirestoreData) -> Void
+		perform?(`path`, `firestoreData`)
+		var __value: DatabaseError? = nil
+		do {
+		    __value = try methodReturnValue(.m_setData__path_pathfirestoreData_firestoreData(Parameter<String>.value(`path`), Parameter<FirestoreData>.value(`firestoreData`))).casted()
+		} catch {
+			// do nothing
+		}
+		return __value
+    }
+
+    open func deleteData(path: String, directory: String) -> DatabaseError? {
+        addInvocation(.m_deleteData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`)))
+		let perform = methodPerformValue(.m_deleteData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))) as? (String, String) -> Void
+		perform?(`path`, `directory`)
+		var __value: DatabaseError? = nil
+		do {
+		    __value = try methodReturnValue(.m_deleteData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))).casted()
+		} catch {
+			// do nothing
+		}
+		return __value
     }
 
 
     fileprivate enum MethodType {
-        case m_enableSaveButtonIfNeeded
+        case m_getData__mainPath_mainPathcondition_condition(Parameter<String>, Parameter<FirestoreQuery?>)
+        case m_getSingleData__path_pathdirectory_directory(Parameter<String>, Parameter<String>)
+        case m_setData__path_pathfirestoreData_firestoreData(Parameter<String>, Parameter<FirestoreData>)
+        case m_deleteData__path_pathdirectory_directory(Parameter<String>, Parameter<String>)
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
-            case (.m_enableSaveButtonIfNeeded, .m_enableSaveButtonIfNeeded): return .match
+            case (.m_getData__mainPath_mainPathcondition_condition(let lhsMainpath, let lhsCondition), .m_getData__mainPath_mainPathcondition_condition(let rhsMainpath, let rhsCondition)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsMainpath, rhs: rhsMainpath, with: matcher), lhsMainpath, rhsMainpath, "mainPath"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCondition, rhs: rhsCondition, with: matcher), lhsCondition, rhsCondition, "condition"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_getSingleData__path_pathdirectory_directory(let lhsPath, let lhsDirectory), .m_getSingleData__path_pathdirectory_directory(let rhsPath, let rhsDirectory)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPath, rhs: rhsPath, with: matcher), lhsPath, rhsPath, "path"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsDirectory, rhs: rhsDirectory, with: matcher), lhsDirectory, rhsDirectory, "directory"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_setData__path_pathfirestoreData_firestoreData(let lhsPath, let lhsFirestoredata), .m_setData__path_pathfirestoreData_firestoreData(let rhsPath, let rhsFirestoredata)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPath, rhs: rhsPath, with: matcher), lhsPath, rhsPath, "path"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsFirestoredata, rhs: rhsFirestoredata, with: matcher), lhsFirestoredata, rhsFirestoredata, "firestoreData"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_deleteData__path_pathdirectory_directory(let lhsPath, let lhsDirectory), .m_deleteData__path_pathdirectory_directory(let rhsPath, let rhsDirectory)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPath, rhs: rhsPath, with: matcher), lhsPath, rhsPath, "path"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsDirectory, rhs: rhsDirectory, with: matcher), lhsDirectory, rhsDirectory, "directory"))
+				return Matcher.ComparisonResult(results)
+            default: return .none
             }
         }
 
         func intValue() -> Int {
             switch self {
-            case .m_enableSaveButtonIfNeeded: return 0
+            case let .m_getData__mainPath_mainPathcondition_condition(p0, p1): return p0.intValue + p1.intValue
+            case let .m_getSingleData__path_pathdirectory_directory(p0, p1): return p0.intValue + p1.intValue
+            case let .m_setData__path_pathfirestoreData_firestoreData(p0, p1): return p0.intValue + p1.intValue
+            case let .m_deleteData__path_pathdirectory_directory(p0, p1): return p0.intValue + p1.intValue
             }
         }
         func assertionName() -> String {
             switch self {
-            case .m_enableSaveButtonIfNeeded: return ".enableSaveButtonIfNeeded()"
+            case .m_getData__mainPath_mainPathcondition_condition: return ".getData(mainPath:condition:)"
+            case .m_getSingleData__path_pathdirectory_directory: return ".getSingleData(path:directory:)"
+            case .m_setData__path_pathfirestoreData_firestoreData: return ".setData(path:firestoreData:)"
+            case .m_deleteData__path_pathdirectory_directory: return ".deleteData(path:directory:)"
             }
         }
     }
@@ -3320,20 +3512,72 @@ open class EditFormDelegateMock: EditFormDelegate, Mock {
         }
 
 
+        public static func getData(mainPath: Parameter<String>, condition: Parameter<FirestoreQuery?>, willReturn: Result<[FirestoreData], DatabaseError>...) -> MethodStub {
+            return Given(method: .m_getData__mainPath_mainPathcondition_condition(`mainPath`, `condition`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
+        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>, willReturn: Result<FirestoreData, DatabaseError>...) -> MethodStub {
+            return Given(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
+        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>, willReturn: DatabaseError?...) -> MethodStub {
+            return Given(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
+        public static func deleteData(path: Parameter<String>, directory: Parameter<String>, willReturn: DatabaseError?...) -> MethodStub {
+            return Given(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
+        public static func getData(mainPath: Parameter<String>, condition: Parameter<FirestoreQuery?>, willProduce: (Stubber<Result<[FirestoreData], DatabaseError>>) -> Void) -> MethodStub {
+            let willReturn: [Result<[FirestoreData], DatabaseError>] = []
+			let given: Given = { return Given(method: .m_getData__mainPath_mainPathcondition_condition(`mainPath`, `condition`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let stubber = given.stub(for: (Result<[FirestoreData], DatabaseError>).self)
+			willProduce(stubber)
+			return given
+        }
+        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>, willProduce: (Stubber<Result<FirestoreData, DatabaseError>>) -> Void) -> MethodStub {
+            let willReturn: [Result<FirestoreData, DatabaseError>] = []
+			let given: Given = { return Given(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let stubber = given.stub(for: (Result<FirestoreData, DatabaseError>).self)
+			willProduce(stubber)
+			return given
+        }
+        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
+            let willReturn: [DatabaseError?] = []
+			let given: Given = { return Given(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let stubber = given.stub(for: (DatabaseError?).self)
+			willProduce(stubber)
+			return given
+        }
+        public static func deleteData(path: Parameter<String>, directory: Parameter<String>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
+            let willReturn: [DatabaseError?] = []
+			let given: Given = { return Given(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
+			let stubber = given.stub(for: (DatabaseError?).self)
+			willProduce(stubber)
+			return given
+        }
     }
 
     public struct Verify {
         fileprivate var method: MethodType
 
-        public static func enableSaveButtonIfNeeded() -> Verify { return Verify(method: .m_enableSaveButtonIfNeeded)}
+        public static func getData(mainPath: Parameter<String>, condition: Parameter<FirestoreQuery?>) -> Verify { return Verify(method: .m_getData__mainPath_mainPathcondition_condition(`mainPath`, `condition`))}
+        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>) -> Verify { return Verify(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`))}
+        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>) -> Verify { return Verify(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`))}
+        public static func deleteData(path: Parameter<String>, directory: Parameter<String>) -> Verify { return Verify(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`))}
     }
 
     public struct Perform {
         fileprivate var method: MethodType
         var performs: Any
 
-        public static func enableSaveButtonIfNeeded(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_enableSaveButtonIfNeeded, performs: perform)
+        public static func getData(mainPath: Parameter<String>, condition: Parameter<FirestoreQuery?>, perform: @escaping (String, FirestoreQuery?) -> Void) -> Perform {
+            return Perform(method: .m_getData__mainPath_mainPathcondition_condition(`mainPath`, `condition`), performs: perform)
+        }
+        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>, perform: @escaping (String, String) -> Void) -> Perform {
+            return Perform(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`), performs: perform)
+        }
+        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>, perform: @escaping (String, FirestoreData) -> Void) -> Perform {
+            return Perform(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`), performs: perform)
+        }
+        public static func deleteData(path: Parameter<String>, directory: Parameter<String>, perform: @escaping (String, String) -> Void) -> Perform {
+            return Perform(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`), performs: perform)
         }
     }
 
@@ -3410,9 +3654,9 @@ open class EditFormDelegateMock: EditFormDelegate, Mock {
     }
 }
 
-// MARK: - FirestoreSession
+// MARK: - FormDelegate
 
-open class FirestoreSessionMock: FirestoreSession, Mock {
+open class FormDelegateMock: FormDelegate, Mock {
     public init(sequencing sequencingPolicy: SequencingPolicy = .lastWrittenResolvedFirst, stubbing stubbingPolicy: StubbingPolicy = .wrap, file: StaticString = #file, line: UInt = #line) {
         SwiftyMockyTestObserver.setup()
         self.sequencingPolicy = sequencingPolicy
@@ -3454,90 +3698,40 @@ open class FirestoreSessionMock: FirestoreSession, Mock {
 
 
 
-    open func getData(mainPath: String) -> Result<[FirestoreData], DatabaseError> {
-        addInvocation(.m_getData__mainPath_mainPath(Parameter<String>.value(`mainPath`)))
-		let perform = methodPerformValue(.m_getData__mainPath_mainPath(Parameter<String>.value(`mainPath`))) as? (String) -> Void
-		perform?(`mainPath`)
-		var __value: Result<[FirestoreData], DatabaseError>
-		do {
-		    __value = try methodReturnValue(.m_getData__mainPath_mainPath(Parameter<String>.value(`mainPath`))).casted()
-		} catch {
-			onFatalFailure("Stub return value not specified for getData(mainPath: String). Use given")
-			Failure("Stub return value not specified for getData(mainPath: String). Use given")
-		}
-		return __value
+    open func enableSaveButtonIfNeeded() {
+        addInvocation(.m_enableSaveButtonIfNeeded)
+		let perform = methodPerformValue(.m_enableSaveButtonIfNeeded) as? () -> Void
+		perform?()
     }
 
-    open func getSingleData(path: String, directory: String) -> Result<FirestoreData, DatabaseError> {
-        addInvocation(.m_getSingleData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`)))
-		let perform = methodPerformValue(.m_getSingleData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))) as? (String, String) -> Void
-		perform?(`path`, `directory`)
-		var __value: Result<FirestoreData, DatabaseError>
-		do {
-		    __value = try methodReturnValue(.m_getSingleData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))).casted()
-		} catch {
-			onFatalFailure("Stub return value not specified for getSingleData(path: String, directory: String). Use given")
-			Failure("Stub return value not specified for getSingleData(path: String, directory: String). Use given")
-		}
-		return __value
+    open func refreshSectionsDependingOnGameFormat() {
+        addInvocation(.m_refreshSectionsDependingOnGameFormat)
+		let perform = methodPerformValue(.m_refreshSectionsDependingOnGameFormat) as? () -> Void
+		perform?()
     }
 
-    open func setData(path: String, firestoreData: FirestoreData) -> DatabaseError? {
-        addInvocation(.m_setData__path_pathfirestoreData_firestoreData(Parameter<String>.value(`path`), Parameter<FirestoreData>.value(`firestoreData`)))
-		let perform = methodPerformValue(.m_setData__path_pathfirestoreData_firestoreData(Parameter<String>.value(`path`), Parameter<FirestoreData>.value(`firestoreData`))) as? (String, FirestoreData) -> Void
-		perform?(`path`, `firestoreData`)
-		var __value: DatabaseError? = nil
-		do {
-		    __value = try methodReturnValue(.m_setData__path_pathfirestoreData_firestoreData(Parameter<String>.value(`path`), Parameter<FirestoreData>.value(`firestoreData`))).casted()
-		} catch {
-			// do nothing
-		}
-		return __value
-    }
-
-    open func deleteData(path: String, directory: String) -> DatabaseError? {
-        addInvocation(.m_deleteData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`)))
-		let perform = methodPerformValue(.m_deleteData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))) as? (String, String) -> Void
-		perform?(`path`, `directory`)
-		var __value: DatabaseError? = nil
-		do {
-		    __value = try methodReturnValue(.m_deleteData__path_pathdirectory_directory(Parameter<String>.value(`path`), Parameter<String>.value(`directory`))).casted()
-		} catch {
-			// do nothing
-		}
-		return __value
+    open func didUpdate(value: Any, for type: FormType) {
+        addInvocation(.m_didUpdate__value_valuefor_type(Parameter<Any>.value(`value`), Parameter<FormType>.value(`type`)))
+		let perform = methodPerformValue(.m_didUpdate__value_valuefor_type(Parameter<Any>.value(`value`), Parameter<FormType>.value(`type`))) as? (Any, FormType) -> Void
+		perform?(`value`, `type`)
     }
 
 
     fileprivate enum MethodType {
-        case m_getData__mainPath_mainPath(Parameter<String>)
-        case m_getSingleData__path_pathdirectory_directory(Parameter<String>, Parameter<String>)
-        case m_setData__path_pathfirestoreData_firestoreData(Parameter<String>, Parameter<FirestoreData>)
-        case m_deleteData__path_pathdirectory_directory(Parameter<String>, Parameter<String>)
+        case m_enableSaveButtonIfNeeded
+        case m_refreshSectionsDependingOnGameFormat
+        case m_didUpdate__value_valuefor_type(Parameter<Any>, Parameter<FormType>)
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
-            case (.m_getData__mainPath_mainPath(let lhsMainpath), .m_getData__mainPath_mainPath(let rhsMainpath)):
-				var results: [Matcher.ParameterComparisonResult] = []
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsMainpath, rhs: rhsMainpath, with: matcher), lhsMainpath, rhsMainpath, "mainPath"))
-				return Matcher.ComparisonResult(results)
+            case (.m_enableSaveButtonIfNeeded, .m_enableSaveButtonIfNeeded): return .match
 
-            case (.m_getSingleData__path_pathdirectory_directory(let lhsPath, let lhsDirectory), .m_getSingleData__path_pathdirectory_directory(let rhsPath, let rhsDirectory)):
-				var results: [Matcher.ParameterComparisonResult] = []
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPath, rhs: rhsPath, with: matcher), lhsPath, rhsPath, "path"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsDirectory, rhs: rhsDirectory, with: matcher), lhsDirectory, rhsDirectory, "directory"))
-				return Matcher.ComparisonResult(results)
+            case (.m_refreshSectionsDependingOnGameFormat, .m_refreshSectionsDependingOnGameFormat): return .match
 
-            case (.m_setData__path_pathfirestoreData_firestoreData(let lhsPath, let lhsFirestoredata), .m_setData__path_pathfirestoreData_firestoreData(let rhsPath, let rhsFirestoredata)):
+            case (.m_didUpdate__value_valuefor_type(let lhsValue, let lhsType), .m_didUpdate__value_valuefor_type(let rhsValue, let rhsType)):
 				var results: [Matcher.ParameterComparisonResult] = []
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPath, rhs: rhsPath, with: matcher), lhsPath, rhsPath, "path"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsFirestoredata, rhs: rhsFirestoredata, with: matcher), lhsFirestoredata, rhsFirestoredata, "firestoreData"))
-				return Matcher.ComparisonResult(results)
-
-            case (.m_deleteData__path_pathdirectory_directory(let lhsPath, let lhsDirectory), .m_deleteData__path_pathdirectory_directory(let rhsPath, let rhsDirectory)):
-				var results: [Matcher.ParameterComparisonResult] = []
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPath, rhs: rhsPath, with: matcher), lhsPath, rhsPath, "path"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsDirectory, rhs: rhsDirectory, with: matcher), lhsDirectory, rhsDirectory, "directory"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsValue, rhs: rhsValue, with: matcher), lhsValue, rhsValue, "value"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsType, rhs: rhsType, with: matcher), lhsType, rhsType, "for type"))
 				return Matcher.ComparisonResult(results)
             default: return .none
             }
@@ -3545,18 +3739,16 @@ open class FirestoreSessionMock: FirestoreSession, Mock {
 
         func intValue() -> Int {
             switch self {
-            case let .m_getData__mainPath_mainPath(p0): return p0.intValue
-            case let .m_getSingleData__path_pathdirectory_directory(p0, p1): return p0.intValue + p1.intValue
-            case let .m_setData__path_pathfirestoreData_firestoreData(p0, p1): return p0.intValue + p1.intValue
-            case let .m_deleteData__path_pathdirectory_directory(p0, p1): return p0.intValue + p1.intValue
+            case .m_enableSaveButtonIfNeeded: return 0
+            case .m_refreshSectionsDependingOnGameFormat: return 0
+            case let .m_didUpdate__value_valuefor_type(p0, p1): return p0.intValue + p1.intValue
             }
         }
         func assertionName() -> String {
             switch self {
-            case .m_getData__mainPath_mainPath: return ".getData(mainPath:)"
-            case .m_getSingleData__path_pathdirectory_directory: return ".getSingleData(path:directory:)"
-            case .m_setData__path_pathfirestoreData_firestoreData: return ".setData(path:firestoreData:)"
-            case .m_deleteData__path_pathdirectory_directory: return ".deleteData(path:directory:)"
+            case .m_enableSaveButtonIfNeeded: return ".enableSaveButtonIfNeeded()"
+            case .m_refreshSectionsDependingOnGameFormat: return ".refreshSectionsDependingOnGameFormat()"
+            case .m_didUpdate__value_valuefor_type: return ".didUpdate(value:for:)"
             }
         }
     }
@@ -3570,72 +3762,28 @@ open class FirestoreSessionMock: FirestoreSession, Mock {
         }
 
 
-        public static func getData(mainPath: Parameter<String>, willReturn: Result<[FirestoreData], DatabaseError>...) -> MethodStub {
-            return Given(method: .m_getData__mainPath_mainPath(`mainPath`), products: willReturn.map({ StubProduct.return($0 as Any) }))
-        }
-        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>, willReturn: Result<FirestoreData, DatabaseError>...) -> MethodStub {
-            return Given(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) }))
-        }
-        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>, willReturn: DatabaseError?...) -> MethodStub {
-            return Given(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`), products: willReturn.map({ StubProduct.return($0 as Any) }))
-        }
-        public static func deleteData(path: Parameter<String>, directory: Parameter<String>, willReturn: DatabaseError?...) -> MethodStub {
-            return Given(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) }))
-        }
-        public static func getData(mainPath: Parameter<String>, willProduce: (Stubber<Result<[FirestoreData], DatabaseError>>) -> Void) -> MethodStub {
-            let willReturn: [Result<[FirestoreData], DatabaseError>] = []
-			let given: Given = { return Given(method: .m_getData__mainPath_mainPath(`mainPath`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
-			let stubber = given.stub(for: (Result<[FirestoreData], DatabaseError>).self)
-			willProduce(stubber)
-			return given
-        }
-        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>, willProduce: (Stubber<Result<FirestoreData, DatabaseError>>) -> Void) -> MethodStub {
-            let willReturn: [Result<FirestoreData, DatabaseError>] = []
-			let given: Given = { return Given(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
-			let stubber = given.stub(for: (Result<FirestoreData, DatabaseError>).self)
-			willProduce(stubber)
-			return given
-        }
-        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
-            let willReturn: [DatabaseError?] = []
-			let given: Given = { return Given(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
-			let stubber = given.stub(for: (DatabaseError?).self)
-			willProduce(stubber)
-			return given
-        }
-        public static func deleteData(path: Parameter<String>, directory: Parameter<String>, willProduce: (Stubber<DatabaseError?>) -> Void) -> MethodStub {
-            let willReturn: [DatabaseError?] = []
-			let given: Given = { return Given(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`), products: willReturn.map({ StubProduct.return($0 as Any) })) }()
-			let stubber = given.stub(for: (DatabaseError?).self)
-			willProduce(stubber)
-			return given
-        }
     }
 
     public struct Verify {
         fileprivate var method: MethodType
 
-        public static func getData(mainPath: Parameter<String>) -> Verify { return Verify(method: .m_getData__mainPath_mainPath(`mainPath`))}
-        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>) -> Verify { return Verify(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`))}
-        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>) -> Verify { return Verify(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`))}
-        public static func deleteData(path: Parameter<String>, directory: Parameter<String>) -> Verify { return Verify(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`))}
+        public static func enableSaveButtonIfNeeded() -> Verify { return Verify(method: .m_enableSaveButtonIfNeeded)}
+        public static func refreshSectionsDependingOnGameFormat() -> Verify { return Verify(method: .m_refreshSectionsDependingOnGameFormat)}
+        public static func didUpdate(value: Parameter<Any>, for type: Parameter<FormType>) -> Verify { return Verify(method: .m_didUpdate__value_valuefor_type(`value`, `type`))}
     }
 
     public struct Perform {
         fileprivate var method: MethodType
         var performs: Any
 
-        public static func getData(mainPath: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
-            return Perform(method: .m_getData__mainPath_mainPath(`mainPath`), performs: perform)
+        public static func enableSaveButtonIfNeeded(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_enableSaveButtonIfNeeded, performs: perform)
         }
-        public static func getSingleData(path: Parameter<String>, directory: Parameter<String>, perform: @escaping (String, String) -> Void) -> Perform {
-            return Perform(method: .m_getSingleData__path_pathdirectory_directory(`path`, `directory`), performs: perform)
+        public static func refreshSectionsDependingOnGameFormat(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_refreshSectionsDependingOnGameFormat, performs: perform)
         }
-        public static func setData(path: Parameter<String>, firestoreData: Parameter<FirestoreData>, perform: @escaping (String, FirestoreData) -> Void) -> Perform {
-            return Perform(method: .m_setData__path_pathfirestoreData_firestoreData(`path`, `firestoreData`), performs: perform)
-        }
-        public static func deleteData(path: Parameter<String>, directory: Parameter<String>, perform: @escaping (String, String) -> Void) -> Perform {
-            return Perform(method: .m_deleteData__path_pathdirectory_directory(`path`, `directory`), performs: perform)
+        public static func didUpdate(value: Parameter<Any>, for type: Parameter<FormType>, perform: @escaping (Any, FormType) -> Void) -> Perform {
+            return Perform(method: .m_didUpdate__value_valuefor_type(`value`, `type`), performs: perform)
         }
     }
 

--- a/GameDexTests/Mock/MockData.swift
+++ b/GameDexTests/Mock/MockData.swift
@@ -163,6 +163,19 @@ enum MockData {
             isPhysical: true
         )
     
+    static let oldSavedGame = SavedGame(
+        game: MockData.games[0],
+        acquisitionYear: "2005",
+        gameCondition: GameCondition.veryGood,
+        gameCompleteness: GameCompleteness.complete,
+        gameRegion: GameRegion.pal,
+        storageArea: "Bedroom",
+        rating: 5,
+        notes: nil,
+        lastUpdated: Date(),
+        isPhysical: true
+    )
+    
     static let savedGames = [
         SavedGame(
             game: MockData.games[0],
@@ -270,14 +283,19 @@ enum MockData {
         )
     ]
     
+    static let firestoreGameCorrectData = FirestoreData(
+        id: "gameId",
+        data: ["title": "gameTitle", "description": "gameDescription", "platform": 4, "imageUrl": "gameImageUrl", "lastUpdated": MockData.timeStamp, "releaseDate": MockData.timeStamp, "notes": "gameNotes", "gameCondition": "mint", "gameCompleteness": "complete", "gameRegion": "pal", "storageArea": "gameStorageArea", "acquisitionYear": "gameAcquisitionYear", "rating": 5, "isPhysical": true, "id": "gameId"]
+    )
+    
     static let firestoreGamesCorrectData = [
         FirestoreData(
             id: "gameId",
-            data: ["title": "gameTitle", "description": "gameDescription", "platform": 4, "imageUrl": "gameImageUrl", "lastUpdated": MockData.timeStamp, "releaseDate": MockData.timeStamp, "notes": "gameNotes", "gameCondition": "mint", "gameCompleteness": "complete", "gameRegion": "pal", "storageArea": "gameStorageArea", "acquisitionYear": "gameAcquisitionYear", "rating": 5, "isPhysical": true]
+            data: ["title": "gameTitle", "description": "gameDescription", "platform": 4, "imageUrl": "gameImageUrl", "lastUpdated": MockData.timeStamp, "releaseDate": MockData.timeStamp, "notes": "gameNotes", "gameCondition": "mint", "gameCompleteness": "complete", "gameRegion": "pal", "storageArea": "gameStorageArea", "acquisitionYear": "gameAcquisitionYear", "rating": 5, "isPhysical": true, "id": "gameId"]
         ),
         FirestoreData(
             id: "gameId",
-            data: ["title": "gameTitle", "description": "gameDescription", "platform": 4, "imageUrl": "gameImageUrl", "lastUpdated": MockData.timeStamp, "releaseDate": MockData.timeStamp, "notes": "gameNotes", "gameCondition": "mint", "gameCompleteness": "complete", "gameRegion": "pal", "storageArea": "gameStorageArea", "acquisitionYear": "gameAcquisitionYear", "rating": 5, "isPhysical": true]
+            data: ["title": "gameTitle", "description": "gameDescription", "platform": 4, "imageUrl": "gameImageUrl", "lastUpdated": MockData.timeStamp, "releaseDate": MockData.timeStamp, "notes": "gameNotes", "gameCondition": "mint", "gameCompleteness": "complete", "gameRegion": "pal", "storageArea": "gameStorageArea", "acquisitionYear": "gameAcquisitionYear", "rating": 5, "isPhysical": true, "id": "gameId"]
         )
     ]
     
@@ -330,4 +348,26 @@ enum MockData {
         GameFilter.acquisitionYear("2019"),
         GameFilter.rating(1)
     ]
+    
+    static let gameForm = GameForm(
+        isPhysical: MockData.savedGame.isPhysical,
+        acquisitionYear: MockData.savedGame.acquisitionYear,
+        gameCondition: MockData.savedGame.gameCondition,
+        gameCompleteness: MockData.savedGame.gameCompleteness,
+        gameRegion: MockData.savedGame.gameRegion,
+        storageArea: MockData.savedGame.storageArea,
+        rating: MockData.savedGame.rating,
+        notes: MockData.savedGame.notes
+    )
+    
+    static let editedGameForm = GameForm(
+        isPhysical: true,
+        acquisitionYear: "2024",
+        gameCondition: GameCondition.mint,
+        gameCompleteness: GameCompleteness.complete,
+        gameRegion: GameRegion.pal,
+        storageArea: "Salon",
+        rating: 4,
+        notes: "notes"
+    )
 }

--- a/GameDexTests/MyCollection/EditGameDetails/EditGameDetailsSectionTests.swift
+++ b/GameDexTests/MyCollection/EditGameDetails/EditGameDetailsSectionTests.swift
@@ -15,11 +15,12 @@ final class EditGameDetailsSectionTests: XCTestCase {
         let section = EditGameDetailsSection(
             savedGame: MockData.savedGame,
             platformName: MockData.platform.title,
-            editDelegate: EditFormDelegateMock()
+            gameForm: MockData.gameForm,
+            formDelegate: FormDelegateMock()
         )
         
         // Then
-        XCTAssertEqual(section.cellsVM.count, 8)
+        XCTAssertEqual(section.cellsVM.count, 9)
         
         guard let gameCellVM = section.cellsVM.first as? ImageDescriptionCellViewModel else {
             XCTFail("Wrong type")
@@ -44,7 +45,7 @@ final class EditGameDetailsSectionTests: XCTestCase {
                 return
             }
             switch formType {
-            case .yearOfAcquisition:
+            case .acquisitionYear:
                 guard let acquisitionYearCellVM = formCellVM as? TextFieldCellViewModel else {
                     XCTFail("Wrong type")
                     return
@@ -130,6 +131,12 @@ final class EditGameDetailsSectionTests: XCTestCase {
                 }
                 XCTAssertEqual(notesCellVM.title, L10n.otherDetails)
                 XCTAssertEqual(notesCellVM.value, MockData.savedGame.notes)
+            case .isPhysical:
+                guard let isPhysicalCellVM = formCellVM as? SegmentedControlCellViewModel else {
+                    XCTFail("Wrong type")
+                    return
+                }
+                XCTAssertEqual(isPhysicalCellVM.value, MockData.savedGame.isPhysical ? L10n.physical : L10n.digital)
             }
         }
     }

--- a/GameDexTests/MyCollection/MyCollectionFilters/MyCollectionFiltersSectionTests.swift
+++ b/GameDexTests/MyCollection/MyCollectionFilters/MyCollectionFiltersSectionTests.swift
@@ -12,11 +12,11 @@ final class MyCollectionFiltersSectionTests: XCTestCase {
     
     func test_initWithoutFilters_ThenShouldSetPropertiesCorrectly() {
         // Given
-        let editFormDelegate = EditFormDelegateMock()
+        let editFormDelegate = FormDelegateMock()
         let section = MyCollectionFiltersSection(
             games: MockData.savedGames,
             selectedFilters: nil,
-            editDelegate: editFormDelegate
+            formDelegate: editFormDelegate
         )
         
         // Then
@@ -146,11 +146,11 @@ final class MyCollectionFiltersSectionTests: XCTestCase {
     
     func test_initWithFilters_ThenShouldSetPropertiesCorrectly() {
         // Given
-        let editFormDelegate = EditFormDelegateMock()
+        let editFormDelegate = FormDelegateMock()
         let section = MyCollectionFiltersSection(
             games: MockData.savedGames,
             selectedFilters: MockData.gameFiltersWithMatchingGames,
-            editDelegate: editFormDelegate
+            formDelegate: editFormDelegate
         )
         
         // Then

--- a/Podfile
+++ b/Podfile
@@ -23,6 +23,7 @@ target 'GameDex' do
   pod 'FirebaseFirestore', :inhibit_warnings => true
   pod 'FirebaseCrashlytics', :inhibit_warnings => true
   pod 'ReachabilitySwift', :inhibit_warnings => true
+  pod 'BetterSegmentedControl', :inhibit_warnings => true
   
 
   target 'GameDexTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -629,6 +629,7 @@ PODS:
     - abseil/base/config
     - abseil/meta/type_traits
   - Alamofire (5.7.1)
+  - BetterSegmentedControl (2.0.1)
   - BoringSSL-GRPC (0.0.24):
     - BoringSSL-GRPC/Implementation (= 0.0.24)
     - BoringSSL-GRPC/Interface (= 0.0.24)
@@ -799,6 +800,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire
+  - BetterSegmentedControl
   - Cosmos (~> 23.0)
   - DTTextField
   - EmptyDataSet-Swift (~> 5.0.0)
@@ -819,6 +821,7 @@ SPEC REPOS:
   trunk:
     - abseil
     - Alamofire
+    - BetterSegmentedControl
     - BoringSSL-GRPC
     - Cosmos
     - DTTextField
@@ -865,6 +868,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   abseil: 926fb7a82dc6d2b8e1f2ed7f3a718bce691d1e46
   Alamofire: 0123a34370cb170936ae79a8df46cc62b2edeb88
+  BetterSegmentedControl: 09607b27861d49cbce48b7673b74f9150a3d371a
   BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
   Cosmos: b5c6a9a637e28a061b54c8f8b1d8529d7d4db73f
   DTTextField: 768d5991211599145f289971e5936f8bb29990bb
@@ -899,6 +903,6 @@ SPEC CHECKSUMS:
   SwiftyMocky: 014739247afadb65efb5bb92ede32c22b9365762
   SwiftyTextView: be873b6b426d148fef9e2a341b3c5989b167572b
 
-PODFILE CHECKSUM: 9eac306adb8b0b8024b0290abdb2cca6a7953328
+PODFILE CHECKSUM: b01aac69aa36591b99000305613b347faa4fe48c
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
We added a segmented control field in the GameDetails form to allow user to indicates whether the game is physical or digital in his collection.

In more details : 
- Use of the pod "BetterSegmentedControl" with a custom view to display an icon + text
- Creation of new SegmentedControlCell + CellVM
- We renamed EditFormDelegate to FormDelegate as it is also used in the AddGameDetails forms to pass the data about game format (AddGameDetails and EditGameDetails will be merged in a future MR)
- Optimization of data transfer with the use of struct GameForm : data is not passed to sections with forms through objects Game or SavedGame but GameForm instead for more consistency
- Rewriting of the database in Firestore (Documents ids for games is no longer the GameID sent by GiantBomb API but a UUID created specifically for each objects in collection. It was mandatory as it is NOT possible to store 2 objects with the same ID in Firestore so it was not possible to store 2 games with same ID but different game format).
- Update of Firebase and CoreData methods to store the new data

| Physical Game Form (light mode)  | Physical Game Form (dark mode)  | Digital Game Form (light mode)  | Digital Game Form (dark mode) |
|---|---|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-03 at 14 05 48](https://github.com/RabiosStudio/GameDex/assets/117658161/095e83ac-8b5c-48b4-8892-2afe2fe12517)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-03 at 14 18 32](https://github.com/RabiosStudio/GameDex/assets/117658161/5451ebfc-72ca-4a6e-9807-6e102996e312)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-03 at 14 05 45](https://github.com/RabiosStudio/GameDex/assets/117658161/a2913c56-e2d2-453c-b360-cb36199e2b61)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-03 at 14 06 04](https://github.com/RabiosStudio/GameDex/assets/117658161/372e7956-94d5-4fc2-a14e-2c26b547eb14)  |