### PR TITLE
Feature/add icon physical or digital to basic cell

### DIFF
--- a/GameDex/AddGame/SelectPlatform/SelectPlatformSection.swift
+++ b/GameDex/AddGame/SelectPlatform/SelectPlatformSection.swift
@@ -16,8 +16,6 @@ final class SelectPlatformSection: Section {
         for platform in platforms {
             let platformCellVM = BasicInfoCellViewModel(
                 title: platform.title,
-                subtitle1: nil,
-                subtitle2: nil,
                 caption: platform.imageUrl,
                 cellTappedCallback: {
                     let screenFactory = SearchGameByTitleScreenFactory(

--- a/GameDex/Common/Cells/BasicCardCell.swift
+++ b/GameDex/Common/Cells/BasicCardCell.swift
@@ -121,7 +121,7 @@ final class BasicCardCell: UICollectionViewCell, CellConfigurable {
         NSLayoutConstraint.activate([
             self.titleLabel.heightAnchor.constraint(
                 equalTo: self.heightAnchor,
-                multiplier: DesignSystem.fractionalSizeVerySmall
+                multiplier: DesignSystem.fractionalSizeTiny
             ),
             self.descriptionLabel.topAnchor.constraint(
                 equalTo: self.titleLabel.bottomAnchor,

--- a/GameDex/Common/Cells/BasicInfoCell.swift
+++ b/GameDex/Common/Cells/BasicInfoCell.swift
@@ -17,6 +17,17 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
         return view
     }()
     
+    private lazy var iconView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFit
+        view.clipsToBounds = true
+        view.tintColor = .primaryColor
+        view.layer.cornerRadius = DesignSystem.cornerRadiusBig
+        view.layer.masksToBounds = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     private lazy var titleLabel: VerticallyAlignedUILabel = {
         let label = VerticallyAlignedUILabel()
         label.font = Typography.title3bold.font
@@ -73,6 +84,11 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
             self.imageView.setImageWith(url: imageURL)
         }
         
+        if let icon = cellVM.icon {
+            self.iconView.image = icon
+            self.iconView.backgroundColor = .primaryBackgroundColor
+        }
+        
         self.titleLabel.text = cellVM.title
         
         self.setupSubviews(
@@ -86,6 +102,7 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
     
     private func setupSubviews(subtitle1: String?, subtitle2: String?) {
         self.contentView.addSubview(self.imageView)
+        self.contentView.addSubview(self.iconView)
         self.stackView.addArrangedSubview(self.titleLabel)
         guard subtitle1 != nil else {
             return
@@ -117,6 +134,20 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
                 constant: -DesignSystem.paddingSmall
             ),
             
+            self.iconView.topAnchor.constraint(
+                equalTo: self.topAnchor
+            ),
+            self.iconView.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor
+            ),
+            self.iconView.heightAnchor.constraint(
+                equalTo: self.imageView.heightAnchor,
+                multiplier: DesignSystem.fractionalSizeVerySmall
+            ),
+            self.iconView.widthAnchor.constraint(
+                equalTo: self.iconView.heightAnchor
+            ),
+            
             self.stackView.topAnchor.constraint(
                 equalTo: self.topAnchor,
                 constant: DesignSystem.paddingSmall
@@ -136,5 +167,7 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
                 equalTo: self.widthAnchor, multiplier: DesignSystem.fractionalSizeBig
             )
         ])
+        self.layoutIfNeeded()
+        self.layoutSubviews()
     }
 }

--- a/GameDex/Common/CellsViewModel/BasicInfoCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/BasicInfoCellViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 final class BasicInfoCellViewModel: CollectionCellViewModel {
     var cellClass: AnyClass = BasicInfoCell.self
@@ -17,18 +18,21 @@ final class BasicInfoCellViewModel: CollectionCellViewModel {
     let subtitle1: String?
     let subtitle2: String?
     let caption: String?
+    let icon: UIImage?
     
     init(
         title: String,
-        subtitle1: String?,
-        subtitle2: String?,
-        caption: String?,
+        subtitle1: String? = nil,
+        subtitle2: String? = nil,
+        caption: String? = nil,
+        icon: UIImage? = nil,
         cellTappedCallback: (() -> Void)? = nil
     ) {
         self.title = title
         self.subtitle1 = subtitle1
         self.subtitle2 = subtitle2
         self.caption = caption
+        self.icon = icon
         self.cellTappedCallback = cellTappedCallback
     }
 }

--- a/GameDex/Common/CellsViewModel/ImageDescriptionCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/ImageDescriptionCellViewModel.swift
@@ -22,7 +22,7 @@ final class ImageDescriptionCellViewModel: CollectionCellViewModel {
     init(imageStringURL: String,
          title: String,
          subtitle1: String,
-         subtitle2: String?,
+         subtitle2: String? = nil,
          subtitle3: String
     ) {
         self.imageStringURL = imageStringURL

--- a/GameDex/CoreData/LocalDatabaseImpl.swift
+++ b/GameDex/CoreData/LocalDatabaseImpl.swift
@@ -95,12 +95,15 @@ extension LocalDatabaseImpl {
         }
     }
     
-    func getGame(gameId: String) -> Result<GameCollected?, DatabaseError> {
+    func getGame(savedGame: SavedGame) -> Result<GameCollected?, DatabaseError> {
         let fetchRequest: NSFetchRequest<GameCollected>
         fetchRequest = GameCollected.fetchRequest()
-        fetchRequest.predicate = NSPredicate(
-            format: "gameID == %@", gameId
-        )
+        
+        let predicateGameID = NSPredicate(format: "gameID == %@", savedGame.game.id)
+        let predicateGameFormat = NSPredicate(format: "isPhysical == %@", NSNumber(value: savedGame.isPhysical))
+        let predicate = NSCompoundPredicate(type: .and, subpredicates: [predicateGameID, predicateGameFormat])
+
+        fetchRequest.predicate = predicate
         
         do {
             let results = try self.managedObjectContext.fetch(fetchRequest)
@@ -114,7 +117,7 @@ extension LocalDatabaseImpl {
     }
     
     func replace(savedGame: SavedGame) async -> DatabaseError? {
-        let gameResult = getGame(gameId: savedGame.game.id)
+        let gameResult = getGame(savedGame: savedGame)
         switch gameResult {
         case let .success(gameToReplace):
             guard let gameToReplace else {
@@ -142,7 +145,7 @@ extension LocalDatabaseImpl {
     
     func remove(savedGame: SavedGame) async -> DatabaseError? {
         // Remove the object in the following context
-        let gameResult = getGame(gameId: savedGame.game.id)
+        let gameResult = getGame(savedGame: savedGame)
         
         switch gameResult {
         case let .success(gameToRemove):

--- a/GameDex/DesignSystem/DesignSystem.swift
+++ b/GameDex/DesignSystem/DesignSystem.swift
@@ -14,7 +14,8 @@ enum DesignSystem {
     static let paddingLarge: CGFloat = 20
     
     // MARK: - Fractional Size
-    static let fractionalSizeVerySmall: CGFloat = 0.15
+    static let fractionalSizeTiny: CGFloat = 0.15
+    static let fractionalSizeVerySmall: CGFloat = 0.20
     static let fractionalSizeSmall: CGFloat = 0.4
     static let fractionalSizeMedium: CGFloat = 0.5
     static let fractionalSizeBig: CGFloat = 0.65

--- a/GameDex/GameDetails/GameDetailsViewModel.swift
+++ b/GameDex/GameDetails/GameDetailsViewModel.swift
@@ -154,7 +154,7 @@ extension GameDetailsViewModel: FormDelegate {
         }
         
         switch self.gameDetailsContext {
-        case .edit(savedGame: let savedGame):
+        case .edit:
             self.configureBottomView(
                 shouldEnableButton: self.initialGameForm != self.gameForm
             )

--- a/GameDex/GameDetails/GameDetailsViewModel.swift
+++ b/GameDex/GameDetails/GameDetailsViewModel.swift
@@ -153,9 +153,14 @@ extension GameDetailsViewModel: FormDelegate {
             }
         }
         
-        self.configureBottomView(
-            shouldEnableButton: self.initialGameForm != self.gameForm
-        )
+        switch self.gameDetailsContext {
+        case .edit(savedGame: let savedGame):
+            self.configureBottomView(
+                shouldEnableButton: self.initialGameForm != self.gameForm
+            )
+        default:
+            break
+        }
     }
     
     func refreshSectionsDependingOnGameFormat() {

--- a/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsSection.swift
+++ b/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsSection.swift
@@ -21,6 +21,7 @@ final class MyCollectionByPlatformsSection: Section {
                 subtitle1: platform.title,
                 subtitle2: item.game.formattedReleaseDate,
                 caption: item.game.imageUrl,
+                icon: item.isPhysical ? GameFormat.physical.image : GameFormat.digital.image,
                 cellTappedCallback: {
                     let screenFactory = GameDetailsScreenFactory(
                         gameDetailsContext: .edit(savedGame: item),

--- a/GameDex/MyCollection/MyCollectionOverview/MyCollectionSection.swift
+++ b/GameDex/MyCollection/MyCollectionOverview/MyCollectionSection.swift
@@ -29,7 +29,6 @@ final class MyCollectionSection: Section {
             let platformCellVM = BasicInfoCellViewModel(
                 title: platform.title,
                 subtitle1: "\(gameArray.count) \(text)",
-                subtitle2: nil,
                 caption: platform.imageUrl,
                 cellTappedCallback: {
                     let screenFactory = MyCollectionByPlatformsScreenFactory(

--- a/GameDexTests/Common/CellsViewModel/BasicInfoCellViewModelTests.swift
+++ b/GameDexTests/Common/CellsViewModel/BasicInfoCellViewModelTests.swift
@@ -13,6 +13,7 @@ final class BasicInfoCellViewModelTests: XCTestCase {
         // Given
         let text = "Title"
         let subtitle1 = "Subtitle 1"
+        let icon = GameFormat.physical.image
         let subtitle2 = "Subtitle 2"
         let captionName = "Caption Name"
         
@@ -21,10 +22,12 @@ final class BasicInfoCellViewModelTests: XCTestCase {
             title: text,
             subtitle1: subtitle1,
             subtitle2: subtitle2,
-            caption: captionName
+            caption: captionName,
+            icon: icon
         )
         // Then
         XCTAssertEqual(cellVM.title, "Title")
+        XCTAssertEqual(cellVM.icon, icon)
         XCTAssertEqual(cellVM.subtitle1, "Subtitle 1")
         XCTAssertEqual(cellVM.subtitle2, "Subtitle 2")
         XCTAssertEqual(cellVM.caption, "Caption Name")


### PR DESCRIPTION
We added an icon on the collection by platform (displaying list of collected game on a specific platform) and indicating the game format (physical or digital).

We also fixed an issue with getGame() in LocalDatabase which did not take into account the game format

In more details :
- BasicInfoCell now includes a UIImage in init
- the UIImage is defined in enum GameFormat

| Collection lightmode  | Collection dark mode  |
|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-04 at 13 42 00](https://github.com/RabiosStudio/GameDex/assets/117658161/61160a8c-6598-4747-88f4-7cd595ca8ac5)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-04 at 13 42 02](https://github.com/RabiosStudio/GameDex/assets/117658161/24cee630-793c-4e2a-820c-ef0b12c21397)  |
