### PR TITLE
Feature/fix search game error empty state

### DIFF
--- a/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleScreenFactory.swift
+++ b/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleScreenFactory.swift
@@ -24,6 +24,7 @@ struct SearchGameByTitleScreenFactory: ScreenFactory {
             viewModel: viewModel,
             layout: layout
         )
+        viewModel.containerDelegate = containerController
         return containerController
     }
     

--- a/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleViewModel.swift
+++ b/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleViewModel.swift
@@ -83,6 +83,8 @@ extension SearchGameByTitleViewModel: SearchViewModelDelegate {
     }
     
     func startSearch(from searchQuery: String, callback: @escaping (EmptyError?) -> ()) {
+        self.sections = []
+        self.containerDelegate?.reloadSections(emptyError: nil)
         Task {
             let endpoint = GetGamesEndpoint(platformId: self.platform.id, title: searchQuery)
             
@@ -95,6 +97,7 @@ extension SearchGameByTitleViewModel: SearchViewModelDelegate {
             case let .success(data):
                 let games = RemoteDataConverter.convert(remoteGames: data.results, platform: self.platform).filter({ $0.releaseDate != nil })
                 guard !games.isEmpty else {
+                    self.sections = []
                     callback(AddGameError.noItems)
                     return
                 }
@@ -106,6 +109,7 @@ extension SearchGameByTitleViewModel: SearchViewModelDelegate {
                 )]
                 callback(nil)
             case .failure(_):
+                self.sections = []
                 callback(AddGameError.server)
             }
         }

--- a/GameDex/Common/Controllers/ContainerViewController.swift
+++ b/GameDex/Common/Controllers/ContainerViewController.swift
@@ -407,13 +407,7 @@ extension ContainerViewController: UICollectionViewDataSource {
 extension ContainerViewController: UISearchTextFieldDelegate {
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         self.viewModel.searchViewModel?.delegate?.updateSearchTextField(with: "", callback: { [weak self] error in
-            if let error = error {
-                let tabBarOffset = -(self?.tabBarController?.tabBar.frame.size.height ?? 0)
-                self?.updateEmptyState(error: error,
-                                       tabBarOffset: tabBarOffset)
-            } else {
-                self?.reloadCollectionView()
-            }
+            self?.reloadSections(emptyError: error)
         })
         return true
     }
@@ -433,17 +427,7 @@ extension ContainerViewController: UISearchBarDelegate {
         
         self.configureLoader()
         self.viewModel.searchViewModel?.delegate?.cancelButtonTapped(callback: { [weak self] error in
-            if let error = error {
-                DispatchQueue.main.async {
-                    let tabBarOffset = -(self?.tabBarController?.tabBar.frame.size.height ?? 0)
-                    self?.updateEmptyState(error: error,
-                                           tabBarOffset: tabBarOffset)
-                }
-            } else {
-                DispatchQueue.main.async {
-                    self?.reloadCollectionView()
-                }
-            }
+            self?.reloadSections(emptyError: error)
         })
     }
     
@@ -459,30 +443,14 @@ extension ContainerViewController: UISearchBarDelegate {
         self.configureLoader()
         self.viewModel.searchViewModel?.delegate?.startSearch(
             from: searchQuery) { [weak self] error in
-                if let error = error {
-                    DispatchQueue.main.async {
-                        let tabBarOffset = -(self?.tabBarController?.tabBar.frame.size.height ?? 0)
-                        self?.updateEmptyState(error: error,
-                                               tabBarOffset: tabBarOffset)
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        self?.reloadCollectionView()
-                    }
-                }
+                self?.reloadSections(emptyError: error)
             }
     }
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         // called when text changes (including clear)
         self.viewModel.searchViewModel?.delegate?.updateSearchTextField(with: searchText) { [weak self] error in
-            if let error = error {
-                let tabBarOffset = -(self?.tabBarController?.tabBar.frame.size.height ?? 0)
-                self?.updateEmptyState(error: error,
-                                       tabBarOffset: tabBarOffset)
-            } else {
-                self?.reloadCollectionView()
-            }
+            self?.reloadSections(emptyError: error)
         }
     }
 }

--- a/GameDexTests/AddGame/SearchGameByTitle/SearchGameByTitleViewModelTests.swift
+++ b/GameDexTests/AddGame/SearchGameByTitle/SearchGameByTitleViewModelTests.swift
@@ -89,6 +89,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         // When
         viewModel.startSearch(from: MockData.searchGameQuery) { error in
@@ -101,6 +103,9 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             XCTAssertEqual(endpoint.url, URL(string: "games"))
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
+        
         wait(for: [expectation], timeout: Constants.timeout)
     }
     
@@ -127,6 +132,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         // When
         viewModel.startSearch(from: MockData.searchGameQuery) { error in
@@ -138,6 +145,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             XCTAssertEqual(error, AddGameError.server)
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
         
         wait(for: [expectation], timeout: Constants.timeout)
     }
@@ -165,6 +174,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         // When
         viewModel.startSearch(from: MockData.searchGameQuery) { error in
@@ -176,6 +187,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             XCTAssertEqual(error, AddGameError.server)
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
         
         wait(for: [expectation], timeout: Constants.timeout)
     }
@@ -203,6 +216,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         // When
         viewModel.startSearch(from: MockData.searchGameQuery) { error in
@@ -214,6 +229,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             XCTAssertEqual(error, AddGameError.server)
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
         
         wait(for: [expectation], timeout: Constants.timeout)
     }
@@ -242,6 +259,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         let games = RemoteDataConverter.convert(
             remoteGames: MockData.searchGamesData.results,
@@ -256,6 +275,9 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
+        
         wait(for: [expectation], timeout: Constants.timeout)
     }
     
@@ -283,6 +305,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         // When
         viewModel.startSearch(from: MockData.searchGameQuery) { error in
@@ -294,6 +318,9 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             XCTAssertEqual(error, AddGameError.noItems)
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
+        
         wait(for: [expectation], timeout: Constants.timeout)
     }
     
@@ -342,6 +369,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         let games = RemoteDataConverter.convert(
             remoteGames: MockData.searchGamesData.results,
@@ -359,6 +388,9 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             }
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
+        
         wait(for: [expectation], timeout: Constants.timeout)
     }
     
@@ -386,6 +418,8 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             progress: DesignSystem.twoThirdProgress,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
+        let containerDelegate = ContainerViewControllerDelegateMock()
+        viewModel.containerDelegate = containerDelegate
         
         let games = RemoteDataConverter.convert(
             remoteGames: MockData.searchGamesData.results,
@@ -406,6 +440,9 @@ final class SearchGameByTitleViewModelTests: XCTestCase {
             }
             expectation.fulfill()
         }
+        
+        containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
+        
         wait(for: [expectation], timeout: Constants.timeout)
     }
     


### PR DESCRIPTION
**What was the issue ?**
When the user had started a game search and its results were displayed, if he started a new search which resulted in error, the sections and empty state were not updated.

**How did we fix this ?**
We emptied sections before returning the error in callback

**Other improvements :** 
1. The loader was not displayed when user started a new search while previous search results were still displayed. This was due to the collection view not being emptied.
-> We added the missing container delegate to the viewModel, emptied section when starting search and reloaded sections before getting searchResults.
2. We used method reloadSections() in ContainerViewController instead of duplicated code lines