### PR TITLE
Feature/remove search bar before collection is loaded and when collection is empty

### DIFF
--- a/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleViewModel.swift
+++ b/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class SearchGameByTitleViewModel: CollectionViewModel {
     lazy var searchViewModel: SearchViewModel? = SearchViewModel(
         placeholder: L10n.searchGame,
+        alwaysShow: true,
         activateOnTap: false,
         delegate: self
     )

--- a/GameDex/AddGame/SelectPlatform/SelectPlatformViewModel.swift
+++ b/GameDex/AddGame/SelectPlatform/SelectPlatformViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class SelectPlatformViewModel: CollectionViewModel {
     lazy var searchViewModel: SearchViewModel? = SearchViewModel(
         placeholder: L10n.searchPlatform,
+        alwaysShow: true,
         activateOnTap: false,
         delegate: self
     )

--- a/GameDex/Common/Controllers/ContainerViewController.swift
+++ b/GameDex/Common/Controllers/ContainerViewController.swift
@@ -15,7 +15,7 @@ protocol ContainerViewControllerDelegate: AnyObject {
     func reloadSections(emptyError: EmptyError?)
     func goBackToRootViewController()
     func goBackToPreviousScreen()
-    func reloadNavBar()
+    func reloadNavBarAndSearchBar()
 }
 
 class ContainerViewController: UIViewController {
@@ -144,7 +144,12 @@ class ContainerViewController: UIViewController {
                             error: error,
                             tabBarOffset: tabBarOffset
                         )
-                        strongSelf.configureNavBarAndSearchBar()
+                        strongSelf.configureNavBar()
+                        if let searchVM = strongSelf.viewModel.searchViewModel, searchVM.alwaysShow {
+                            strongSelf.configureSearchBar()
+                        } else {
+                            strongSelf.searchBar.removeFromSuperview()
+                        }
                     } else {
                         strongSelf.refresh()
                     }
@@ -156,7 +161,8 @@ class ContainerViewController: UIViewController {
     }
     
     private func refresh() {
-        self.configureNavBarAndSearchBar()
+        self.configureNavBar()
+        self.configureSearchBar()
         self.reloadCollectionView()
     }
     
@@ -207,10 +213,9 @@ class ContainerViewController: UIViewController {
         self.title = self.viewModel.screenTitle
     }
     
-    private func configureNavBarAndSearchBar() {
+    private func configureNavBar() {
         DispatchQueue.main.async {
             self.navigationController?.configure()
-            self.configureSearchBar()
             
             guard let buttonItems = self.viewModel.buttonItems else {
                 return
@@ -533,8 +538,9 @@ extension ContainerViewController: ContainerViewControllerDelegate {
         }
     }
     
-    func reloadNavBar() {
-        self.configureNavBarAndSearchBar()
+    func reloadNavBarAndSearchBar() {
+        self.configureNavBar()
+        self.configureSearchBar()
     }
 }
 

--- a/GameDex/CoreData/CoreDataConverter.swift
+++ b/GameDex/CoreData/CoreDataConverter.swift
@@ -17,6 +17,13 @@ enum CoreDataConverter {
         platformCollected.id = Int16(platform.id)
         platformCollected.title = platform.title
         platformCollected.imageUrl = platform.imageUrl
+        
+        let supportedNames = platform.supportedNames.map { aName in
+            let supportedName = PlatformSupportedNames(context: context)
+            supportedName.name = aName
+            return supportedName
+        }
+        platformCollected.supportedNames = NSSet(array: supportedNames)
                 
         guard let platformGames = platform.games else {
             return platformCollected
@@ -27,13 +34,6 @@ enum CoreDataConverter {
             return gameCollected
         }
         
-        let supportedNames = platform.supportedNames.map { aName in
-            let supportedName = PlatformSupportedNames(context: context)
-            supportedName.name = aName
-            return supportedName
-        }
-        
-        platformCollected.supportedNames = NSSet(array: supportedNames)
         platformCollected.games = NSSet(array: gamesCollected)
         return platformCollected
     }

--- a/GameDex/Helpers/SearchViewModel.swift
+++ b/GameDex/Helpers/SearchViewModel.swift
@@ -33,6 +33,7 @@ extension SearchViewModelDelegate {
 
 struct SearchViewModel {
     let placeholder: String
+    let alwaysShow: Bool
     let activateOnTap: Bool
     var delegate: SearchViewModelDelegate?
 }

--- a/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class MyCollectionByPlatformsViewModel: ConnectivityDisplayerViewModel {
     lazy var searchViewModel: SearchViewModel? = SearchViewModel(
         placeholder: L10n.searchGame,
+        alwaysShow: true,
         activateOnTap: true,
         delegate: self
     )
@@ -163,7 +164,7 @@ extension MyCollectionByPlatformsViewModel: MyCollectionViewModelDelegate {
         self.updateListOfGames(with: games)
         self.displayedGames = games
         self.buttonItems = [.filter(active: false), .add]
-        self.containerDelegate?.reloadNavBar()
+        self.containerDelegate?.reloadNavBarAndSearchBar()
         self.containerDelegate?.reloadSections(emptyError: nil)
     }
     
@@ -197,7 +198,7 @@ extension MyCollectionByPlatformsViewModel: MyCollectionViewModelDelegate {
         self.containerDelegate?.reloadSections(
             emptyError: filteredGames.isEmpty ? MyCollectionError.noItems(delegate: self) : nil
         )
-        self.containerDelegate?.reloadNavBar()
+        self.containerDelegate?.reloadNavBarAndSearchBar()
     }
     
     private func shouldDisplayGame(game: SavedGame, filter: GameFilter) -> Bool {

--- a/GameDex/MyCollection/MyCollectionOverview/MyCollectionViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionOverview/MyCollectionViewModel.swift
@@ -18,6 +18,7 @@ protocol MyCollectionViewModelDelegate: AnyObject {
 final class MyCollectionViewModel: ConnectivityDisplayerViewModel {
     lazy var searchViewModel: SearchViewModel? = SearchViewModel(
         placeholder: L10n.searchCollection,
+        alwaysShow: false,
         activateOnTap: true,
         delegate: self
     )

--- a/GameDexTests/Mock/Mock.generated.swift
+++ b/GameDexTests/Mock/Mock.generated.swift
@@ -3172,9 +3172,9 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
 		perform?()
     }
 
-    open func reloadNavBar() {
-        addInvocation(.m_reloadNavBar)
-		let perform = methodPerformValue(.m_reloadNavBar) as? () -> Void
+    open func reloadNavBarAndSearchBar() {
+        addInvocation(.m_reloadNavBarAndSearchBar)
+		let perform = methodPerformValue(.m_reloadNavBarAndSearchBar) as? () -> Void
 		perform?()
     }
 
@@ -3185,7 +3185,7 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
         case m_reloadSections__emptyError_emptyError(Parameter<EmptyError?>)
         case m_goBackToRootViewController
         case m_goBackToPreviousScreen
-        case m_reloadNavBar
+        case m_reloadNavBarAndSearchBar
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -3205,7 +3205,7 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
 
             case (.m_goBackToPreviousScreen, .m_goBackToPreviousScreen): return .match
 
-            case (.m_reloadNavBar, .m_reloadNavBar): return .match
+            case (.m_reloadNavBarAndSearchBar, .m_reloadNavBarAndSearchBar): return .match
             default: return .none
             }
         }
@@ -3217,7 +3217,7 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
             case let .m_reloadSections__emptyError_emptyError(p0): return p0.intValue
             case .m_goBackToRootViewController: return 0
             case .m_goBackToPreviousScreen: return 0
-            case .m_reloadNavBar: return 0
+            case .m_reloadNavBarAndSearchBar: return 0
             }
         }
         func assertionName() -> String {
@@ -3227,7 +3227,7 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
             case .m_reloadSections__emptyError_emptyError: return ".reloadSections(emptyError:)"
             case .m_goBackToRootViewController: return ".goBackToRootViewController()"
             case .m_goBackToPreviousScreen: return ".goBackToPreviousScreen()"
-            case .m_reloadNavBar: return ".reloadNavBar()"
+            case .m_reloadNavBarAndSearchBar: return ".reloadNavBarAndSearchBar()"
             }
         }
     }
@@ -3251,7 +3251,7 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
         public static func reloadSections(emptyError: Parameter<EmptyError?>) -> Verify { return Verify(method: .m_reloadSections__emptyError_emptyError(`emptyError`))}
         public static func goBackToRootViewController() -> Verify { return Verify(method: .m_goBackToRootViewController)}
         public static func goBackToPreviousScreen() -> Verify { return Verify(method: .m_goBackToPreviousScreen)}
-        public static func reloadNavBar() -> Verify { return Verify(method: .m_reloadNavBar)}
+        public static func reloadNavBarAndSearchBar() -> Verify { return Verify(method: .m_reloadNavBarAndSearchBar)}
     }
 
     public struct Perform {
@@ -3273,8 +3273,8 @@ open class ContainerViewControllerDelegateMock: ContainerViewControllerDelegate,
         public static func goBackToPreviousScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_goBackToPreviousScreen, performs: perform)
         }
-        public static func reloadNavBar(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_reloadNavBar, performs: perform)
+        public static func reloadNavBarAndSearchBar(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_reloadNavBarAndSearchBar, performs: perform)
         }
     }
 

--- a/GameDexTests/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformViewModelTests.swift
+++ b/GameDexTests/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformViewModelTests.swift
@@ -708,7 +708,7 @@ final class MyCollectionByPlatformViewModelTests: XCTestCase {
         await viewModel.clearFilters()
         
         // Then
-        containerDelegate.verify(.reloadNavBar(), count: .once)
+        containerDelegate.verify(.reloadNavBarAndSearchBar(), count: .once)
         containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
     }
     
@@ -737,7 +737,7 @@ final class MyCollectionByPlatformViewModelTests: XCTestCase {
         await viewModel.apply(filters: MockData.gameFiltersWithMatchingGames)
         
         // Then
-        containerDelegate.verify(.reloadNavBar(), count: .once)
+        containerDelegate.verify(.reloadNavBarAndSearchBar(), count: .once)
         containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
     }
     
@@ -766,7 +766,7 @@ final class MyCollectionByPlatformViewModelTests: XCTestCase {
         await viewModel.apply(filters: MockData.gameFiltersWithNoMatchingGames)
         
         // Then
-        containerDelegate.verify(.reloadNavBar(), count: .once)
+        containerDelegate.verify(.reloadNavBarAndSearchBar(), count: .once)
         containerDelegate.verify(.reloadSections(emptyError: .any), count: .once)
     }
 


### PR DESCRIPTION
**What was the issue ?**
The search bar was configured before data was loaded and was not removed when collection was empty.

**How did we fix this ?**
- New Boolean var "alwaysShow" to SearchViewModel.
- "alwaysShow" is defined to true for almost all VM besides MyCollection (where the searchBar has to be removed)
- Removed configuration of searchBar in configureNavBarAndSearchBar() and renamed method to configureNavBar()
- In ContainerController loadData(), if there is an error, we remove the searchBar if needed or we configure it.

**Other improvements :** 
There was an issue with saving platform's supported names in CoreData when it was the first time adding the platform. This caused issues when using the searchBar on MyCollection.
-> We fixed this bar simply moving the code lines to save supported names before exiting the method due to platform having no savedGames

| BEFORE (empty collection) | AFTER (empty collection) | AFTER (collection with games)  |
|---|---|---|
| ![Simulator Screenshot - iPhone 14 Pro - 2024-06-04 at 15 40 13](https://github.com/RabiosStudio/GameDex/assets/117658161/0f47dfc9-b892-42fc-8f53-3bf1c3a04155)  | ![Simulator Screenshot - iPhone 14 Pro - 2024-06-04 at 15 36 05](https://github.com/RabiosStudio/GameDex/assets/117658161/8bc69414-b706-4725-88ea-4c3e0812c5eb)  | ![Simulator Screenshot - iPhone 14 Pro - 2024-06-04 at 15 36 19](https://github.com/RabiosStudio/GameDex/assets/117658161/c6a929ca-1a19-41ff-ad04-b83f3dbb9560)  |
