### PR TITLE
Feature/add new filter on game format

### DIFF
--- a/GameDex.xcodeproj/project.pbxproj
+++ b/GameDex.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		25BA888A2C0E040600B8CD28 /* GameDetailsScreenFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA88892C0E040600B8CD28 /* GameDetailsScreenFactory.swift */; };
 		25BA888D2C0F03AD00B8CD28 /* GameDetailsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA888C2C0F03AD00B8CD28 /* GameDetailsSectionTests.swift */; };
 		25BA888F2C0F03BA00B8CD28 /* GameDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA888E2C0F03BA00B8CD28 /* GameDetailsViewModelTests.swift */; };
+		25BA889D2C11BA8B00B8CD28 /* GameFilterForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA889C2C11BA8B00B8CD28 /* GameFilterForm.swift */; };
 		25BDEC8A2AC5781C0083E0B2 /* FirestoreDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BDEC892AC5781C0083E0B2 /* FirestoreDatabase.swift */; };
 		25D5074D2AB61BB200A772F9 /* MyCollectionSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5074C2AB61BB200A772F9 /* MyCollectionSectionTests.swift */; };
 		25D507512AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D507502AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift */; };
@@ -377,6 +378,7 @@
 		25BA88892C0E040600B8CD28 /* GameDetailsScreenFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailsScreenFactory.swift; sourceTree = "<group>"; };
 		25BA888C2C0F03AD00B8CD28 /* GameDetailsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailsSectionTests.swift; sourceTree = "<group>"; };
 		25BA888E2C0F03BA00B8CD28 /* GameDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailsViewModelTests.swift; sourceTree = "<group>"; };
+		25BA889C2C11BA8B00B8CD28 /* GameFilterForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameFilterForm.swift; sourceTree = "<group>"; };
 		25BDEC892AC5781C0083E0B2 /* FirestoreDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreDatabase.swift; sourceTree = "<group>"; };
 		25D5074C2AB61BB200A772F9 /* MyCollectionSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionSectionTests.swift; sourceTree = "<group>"; };
 		25D507502AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionByPlatformSectionTests.swift; sourceTree = "<group>"; };
@@ -566,6 +568,7 @@
 				255A0A472C035DDD007ED3D3 /* GameFilterFormType.swift */,
 				255A0A512C072BDF007ED3D3 /* SegmentItem.swift */,
 				25BA88802C09C9FE00B8CD28 /* GameForm.swift */,
+				25BA889C2C11BA8B00B8CD28 /* GameFilterForm.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1490,6 +1493,7 @@
 				2586302A2BF3727000AD3EE4 /* PlatformSupportedNames.swift in Sources */,
 				251C873D2A9D09AA0020C794 /* BasicInfoCellViewModel.swift in Sources */,
 				254354782A93B1BB00E53351 /* LabelCellViewModel.swift in Sources */,
+				25BA889D2C11BA8B00B8CD28 /* GameFilterForm.swift in Sources */,
 				255A0A482C035DDD007ED3D3 /* GameFilterFormType.swift in Sources */,
 				254E8B912A8B6BC000C101C8 /* Assets.swift in Sources */,
 				254E8B852A8A81F400C101C8 /* UIColorExtension.swift in Sources */,

--- a/GameDex.xcodeproj/project.pbxproj
+++ b/GameDex.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		25BA888D2C0F03AD00B8CD28 /* GameDetailsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA888C2C0F03AD00B8CD28 /* GameDetailsSectionTests.swift */; };
 		25BA888F2C0F03BA00B8CD28 /* GameDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA888E2C0F03BA00B8CD28 /* GameDetailsViewModelTests.swift */; };
 		25BA889D2C11BA8B00B8CD28 /* GameFilterForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BA889C2C11BA8B00B8CD28 /* GameFilterForm.swift */; };
+		25BA88A12C18440A00B8CD28 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 25BA88A02C18440A00B8CD28 /* GoogleService-Info.plist */; };
 		25BDEC8A2AC5781C0083E0B2 /* FirestoreDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BDEC892AC5781C0083E0B2 /* FirestoreDatabase.swift */; };
 		25D5074D2AB61BB200A772F9 /* MyCollectionSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5074C2AB61BB200A772F9 /* MyCollectionSectionTests.swift */; };
 		25D507512AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D507502AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift */; };
@@ -174,8 +175,6 @@
 		25E8E49F2AC1B0D80093E7F8 /* AuthenticationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E8E49E2AC1B0D80093E7F8 /* AuthenticationViewModelTests.swift */; };
 		25E8E4A12AC1B1050093E7F8 /* AuthenticationSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E8E4A02AC1B1050093E7F8 /* AuthenticationSectionTests.swift */; };
 		25E8E4A32AC1B7AF0093E7F8 /* CellSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E8E4A22AC1B7AF0093E7F8 /* CellSize.swift */; };
-		25E8E4A52AC1C2380093E7F8 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 25E8E4A42AC1C2380093E7F8 /* GoogleService-Info.plist */; };
-		25E8E4A62AC1C2380093E7F8 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 25E8E4A42AC1C2380093E7F8 /* GoogleService-Info.plist */; };
 		25E8E4A82AC1E4290093E7F8 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E8E4A72AC1E4290093E7F8 /* AuthenticationService.swift */; };
 		25E8E4AC2AC1E4BC0093E7F8 /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E8E4AB2AC1E4BC0093E7F8 /* AuthenticationError.swift */; };
 		25E8E4B12AC428880093E7F8 /* AuthenticationServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E8E4B02AC428880093E7F8 /* AuthenticationServiceImpl.swift */; };
@@ -379,6 +378,7 @@
 		25BA888C2C0F03AD00B8CD28 /* GameDetailsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailsSectionTests.swift; sourceTree = "<group>"; };
 		25BA888E2C0F03BA00B8CD28 /* GameDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		25BA889C2C11BA8B00B8CD28 /* GameFilterForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameFilterForm.swift; sourceTree = "<group>"; };
+		25BA88A02C18440A00B8CD28 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		25BDEC892AC5781C0083E0B2 /* FirestoreDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreDatabase.swift; sourceTree = "<group>"; };
 		25D5074C2AB61BB200A772F9 /* MyCollectionSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionSectionTests.swift; sourceTree = "<group>"; };
 		25D507502AB6DCAD00A772F9 /* MyCollectionByPlatformSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCollectionByPlatformSectionTests.swift; sourceTree = "<group>"; };
@@ -396,7 +396,6 @@
 		25E8E49E2AC1B0D80093E7F8 /* AuthenticationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewModelTests.swift; sourceTree = "<group>"; };
 		25E8E4A02AC1B1050093E7F8 /* AuthenticationSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationSectionTests.swift; sourceTree = "<group>"; };
 		25E8E4A22AC1B7AF0093E7F8 /* CellSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellSize.swift; sourceTree = "<group>"; };
-		25E8E4A42AC1C2380093E7F8 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		25E8E4A72AC1E4290093E7F8 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
 		25E8E4AB2AC1E4BC0093E7F8 /* AuthenticationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationError.swift; sourceTree = "<group>"; };
 		25E8E4B02AC428880093E7F8 /* AuthenticationServiceImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthenticationServiceImpl.swift; path = Authentication/AuthenticationServiceImpl.swift; sourceTree = "<group>"; };
@@ -963,7 +962,7 @@
 				25D6EAE12A8A265C00C2BE57 /* AppDelegate.swift */,
 				25D6EAEC2A8A265D00C2BE57 /* LaunchScreen.storyboard */,
 				25D6EAEF2A8A265D00C2BE57 /* Info.plist */,
-				25E8E4A42AC1C2380093E7F8 /* GoogleService-Info.plist */,
+				25BA88A02C18440A00B8CD28 /* GoogleService-Info.plist */,
 			);
 			path = GameDex;
 			sourceTree = "<group>";
@@ -1241,7 +1240,7 @@
 				254E8B7E2A8A7D2600C101C8 /* Localizable.strings in Resources */,
 				25D6EAEB2A8A265D00C2BE57 /* Assets.xcassets in Resources */,
 				254E8B8D2A8B69E000C101C8 /* swiftgen.yml in Resources */,
-				25E8E4A52AC1C2380093E7F8 /* GoogleService-Info.plist in Resources */,
+				25BA88A12C18440A00B8CD28 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1250,7 +1249,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				254E8B8E2A8B69E000C101C8 /* swiftgen.yml in Resources */,
-				25E8E4A62AC1C2380093E7F8 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1765,6 +1763,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1783,6 +1782,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rabios.GameDex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1799,6 +1799,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = R42ZG629VC;
@@ -1816,6 +1817,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rabios.GameDex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1837,7 +1839,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.dalbera.GameDexTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rabios.GameDexTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -1857,7 +1859,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.dalbera.GameDexTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rabios.GameDexTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;

--- a/GameDex/AppDelegate.swift
+++ b/GameDex/AppDelegate.swift
@@ -20,14 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         window?.rootViewController = TabBarController()
         window?.makeKeyAndVisible()
-        self.configureKeyboardManager()
         
         return true
-    }
-    
-    private func configureKeyboardManager() {
-        IQKeyboardManager.shared.enable = true
-        IQKeyboardManager.shared.shouldToolbarUsesTextFieldTintColor = true
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
     }
 }

--- a/GameDex/Common/Cells/TextViewCell.swift
+++ b/GameDex/Common/Cells/TextViewCell.swift
@@ -48,12 +48,6 @@ class TextViewCell: UICollectionViewCell, CellConfigurable {
         return nil
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        self.textView.text = nil
-        self.label.text = nil
-    }
-    
     func configure(cellViewModel: CellViewModel) {
         guard let cellVM = cellViewModel as? TextViewCellViewModel else {
             return

--- a/GameDex/Common/Controllers/ContainerViewController.swift
+++ b/GameDex/Common/Controllers/ContainerViewController.swift
@@ -261,13 +261,15 @@ class ContainerViewController: UIViewController {
     }
     
     private func configureSearchBar() {
-        guard let searchVM = self.viewModel.searchViewModel else {
-            self.searchBar.removeFromSuperview()
-            return
+        DispatchQueue.main.async {
+            guard let searchVM = self.viewModel.searchViewModel else {
+                self.searchBar.removeFromSuperview()
+                return
+            }
+            self.searchBar.text = nil
+            self.searchBar.placeholder = searchVM.placeholder
+            self.stackView.insertArrangedSubview(self.searchBar, at: .zero)
         }
-        self.searchBar.text = nil
-        self.searchBar.placeholder = searchVM.placeholder
-        self.stackView.insertArrangedSubview(self.searchBar, at: .zero)
     }
     
     private func makeSearchBarFirstResponderIfNeeded() {

--- a/GameDex/Common/Model/GameFilter.swift
+++ b/GameDex/Common/Model/GameFilter.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-enum GameFilter: Filter {
+enum GameFilter: Filter, Equatable {
+    case isPhysical(Bool)
     case acquisitionYear(String)
     case gameCondition(GameCondition.RawValue)
     case gameCompleteness(GameCompleteness.RawValue)
@@ -21,23 +22,27 @@ enum GameFilter: Filter {
             return String(value) as? T
         case let .rating(value):
             return Int(value) as? T
+        case let .isPhysical(value):
+            return Bool(value) as? T
         }
     }
     
     var keyPath: PartialKeyPath<SavedGame> {
         switch self {
-        case .acquisitionYear(_):
+        case .acquisitionYear:
             return \SavedGame.acquisitionYear
-        case .gameCondition(_):
+        case .gameCondition:
             return \SavedGame.gameCondition?.rawValue
-        case .gameCompleteness(_):
+        case .gameCompleteness:
             return \SavedGame.gameCompleteness?.rawValue
-        case .gameRegion(_):
+        case .gameRegion:
             return \SavedGame.gameRegion?.rawValue
-        case .storageArea(_):
+        case .storageArea:
             return \SavedGame.storageArea
-        case .rating(_):
+        case .rating:
             return \SavedGame.rating
+        case .isPhysical:
+            return \SavedGame.isPhysical
         }
     }
 }

--- a/GameDex/Common/Model/GameFilterForm.swift
+++ b/GameDex/Common/Model/GameFilterForm.swift
@@ -1,0 +1,18 @@
+//
+//  GameFilterForm.swift
+//  GameDex
+//
+//  Created by Gabrielle Dalbera on 06/06/2024.
+//
+
+import Foundation
+
+struct GameFilterForm: Equatable {
+    var isPhysical: Bool?
+    var acquisitionYear: String?
+    var gameCondition: GameCondition?
+    var gameCompleteness: GameCompleteness?
+    var gameRegion: GameRegion?
+    var storageArea: String?
+    var rating: Int?
+}

--- a/GameDex/Common/Model/GameFilterFormType.swift
+++ b/GameDex/Common/Model/GameFilterFormType.swift
@@ -9,7 +9,8 @@ import Foundation
 import UIKit
 
 enum GameFilterFormType: FormType, Equatable {
-    case yearOfAcquisition(PickerViewModel)
+    case isPhysical(PickerViewModel)
+    case acquisitionYear(PickerViewModel)
     case gameCondition(PickerViewModel)
     case gameCompleteness(PickerViewModel)
     case gameRegion(PickerViewModel)
@@ -29,7 +30,7 @@ enum GameFilterFormType: FormType, Equatable {
     
     var inputPickerViewModel: PickerViewModel? {
         switch self {
-        case let .gameCompleteness(pickerVM), let .gameCondition(pickerVM), let .gameRegion(pickerVM), let .yearOfAcquisition(pickerVM), let .storageArea(pickerVM):
+        case let .gameCompleteness(pickerVM), let .gameCondition(pickerVM), let .gameRegion(pickerVM), let .acquisitionYear(pickerVM), let .storageArea(pickerVM), let .isPhysical(pickerVM):
             return pickerVM
         case .rating:
             return nil

--- a/GameDex/GoogleService-Info.plist
+++ b/GameDex/GoogleService-Info.plist
@@ -15,16 +15,16 @@
 	<key>STORAGE_BUCKET</key>
 	<string>gamedex-91898.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
-	<false/>
+	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
-	<false/>
+	<false></false>
 	<key>IS_APPINVITE_ENABLED</key>
-	<true/>
+	<true></true>
 	<key>IS_GCM_ENABLED</key>
-	<true/>
+	<true></true>
 	<key>IS_SIGNIN_ENABLED</key>
-	<true/>
+	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:932043532731:ios:631bdd4f48459375e73c9e</string>
+	<string>1:932043532731:ios:fa030ab2afb82a80e73c9e</string>
 </dict>
 </plist>

--- a/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
@@ -36,6 +36,7 @@ final class MyCollectionByPlatformsViewModel: ConnectivityDisplayerViewModel {
     private var platform: Platform?
     private var displayedGames: [SavedGame]
     private var selectedFilters: [GameFilter]?
+    private var gameFilterForm: GameFilterForm?
     let authenticationService: AuthenticationService
     let connectivityChecker: ConnectivityChecker
     
@@ -58,6 +59,7 @@ final class MyCollectionByPlatformsViewModel: ConnectivityDisplayerViewModel {
         self.screenTitle = self.platform?.title
         self.displayedGames = self.platform?.games ?? []
         self.selectedFilters = nil
+        self.gameFilterForm = nil
         self.buttonItems = [.filter(active: false), .add]
     }
     
@@ -115,7 +117,7 @@ final class MyCollectionByPlatformsViewModel: ConnectivityDisplayerViewModel {
             navigationStyle: .present(
                 screenFactory: MyCollectionFiltersScreenFactory(
                     games: games,
-                    selectedFilters: self.selectedFilters ?? nil,
+                    gameFilterForm: self.gameFilterForm ?? nil,
                     myCollectionDelegate: self
                 ),
                 completionBlock: nil
@@ -168,6 +170,50 @@ extension MyCollectionByPlatformsViewModel: MyCollectionViewModelDelegate {
         self.containerDelegate?.reloadSections(emptyError: nil)
     }
     
+    private func createGameFilterForm(from filters: [GameFilter]){
+        var isPhysicalFilterValue: Bool?
+        var acquisitionYearFilterValue: String?
+        var gameConditionFilterValue: GameCondition?
+        var gameCompletenessFilterValue: GameCompleteness?
+        var gameRegionFilterValue: GameRegion?
+        var storageAreaFilterValue: String?
+        var ratingFilterValue: Int?
+        
+        for filter in filters {
+            switch filter {
+            case let .isPhysical(value):
+                isPhysicalFilterValue = value
+            case let .acquisitionYear(value):
+                acquisitionYearFilterValue = value
+            case let .gameCondition(value):
+                if let gameCondition = GameCondition(rawValue: value) {
+                    gameConditionFilterValue = gameCondition
+                }
+            case let .gameCompleteness(value):
+                if let gameCompleteness = GameCompleteness(rawValue: value) {
+                    gameCompletenessFilterValue = gameCompleteness
+                }
+            case let .gameRegion(value):
+                if let gameRegion = GameRegion(rawValue: value) {
+                    gameRegionFilterValue = gameRegion
+                }
+            case let .storageArea(value):
+                storageAreaFilterValue = value
+            case let .rating(value):
+                ratingFilterValue = value
+            }
+        }
+        self.gameFilterForm = GameFilterForm(
+            isPhysical: isPhysicalFilterValue,
+            acquisitionYear: acquisitionYearFilterValue,
+            gameCondition: gameConditionFilterValue,
+            gameCompleteness: gameCompletenessFilterValue,
+            gameRegion: gameRegionFilterValue,
+            storageArea: storageAreaFilterValue,
+            rating: ratingFilterValue
+        )
+    }
+    
     func apply(filters: [GameFilter]) async {
         guard let games = self.platform?.games,
               !filters.isEmpty else {
@@ -175,11 +221,15 @@ extension MyCollectionByPlatformsViewModel: MyCollectionViewModelDelegate {
             return
         }
         self.selectedFilters = filters
+        self.createGameFilterForm(from: filters)
+        
+        let newFilters = self.removeFiltersDependingOnGameFormat(filters: filters)
+        
         var shouldKeepGame = false
         var filteredGames = [SavedGame]()
         for index in 0..<games.count {
             let currentGame = games[index]
-            for filter in filters {
+            for filter in newFilters {
                 shouldKeepGame = self.shouldDisplayGame(
                     game: currentGame,
                     filter: filter
@@ -209,8 +259,31 @@ extension MyCollectionByPlatformsViewModel: MyCollectionViewModelDelegate {
         } else if let gameData = game[keyPath: filter.keyPath] as? Int,
                   let filterIntValue: Int = filter.value() {
             shouldDisplayGame = filterIntValue == gameData
+        } else if let gameData = game[keyPath: filter.keyPath] as? Bool,
+                  let filterBoolValue: Bool = filter.value() {
+            shouldDisplayGame = filterBoolValue == gameData
         }
         return shouldDisplayGame
+    }
+    
+    private func removeFiltersDependingOnGameFormat(filters: [GameFilter]) -> [GameFilter] {
+        guard filters.contains(where: { aFilter in
+            aFilter.self == .isPhysical(false)
+        }) else {
+            // Filter on game format "Physical"
+            return filters
+        }
+        // Filter on game format "Digital", we need to remove filters that apply only to Physical games
+        var newGameFilters = [GameFilter]()
+        for filter in filters {
+            switch filter {
+            case .acquisitionYear, .isPhysical, .rating:
+                newGameFilters.append(filter)
+            case .gameCondition, .gameCompleteness, .gameRegion, .storageArea:
+                break
+            }
+        }
+        return newGameFilters
     }
     
     func reloadCollection() async {

--- a/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
@@ -170,7 +170,7 @@ extension MyCollectionByPlatformsViewModel: MyCollectionViewModelDelegate {
         self.containerDelegate?.reloadSections(emptyError: nil)
     }
     
-    private func createGameFilterForm(from filters: [GameFilter]){
+    private func createGameFilterForm(from filters: [GameFilter]) {
         var isPhysicalFilterValue: Bool?
         var acquisitionYearFilterValue: String?
         var gameConditionFilterValue: GameCondition?

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersScreenFactory.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersScreenFactory.swift
@@ -11,13 +11,13 @@ import UIKit
 struct MyCollectionFiltersScreenFactory: ScreenFactory {
     
     private let games: [SavedGame]
-    private let selectedFilters: [GameFilter]?
+    private let gameFilterForm: GameFilterForm?
     private weak var myCollectionDelegate: MyCollectionViewModelDelegate?
     
     var viewController: UIViewController {
         let viewModel = MyCollectionFiltersViewModel(
             games: self.games,
-            selectedFilters: self.selectedFilters ?? nil,
+            gameFilterForm: self.gameFilterForm ?? nil,
             myCollectionDelegate: self.myCollectionDelegate
         )
         let layout = UICollectionViewFlowLayout()
@@ -31,11 +31,11 @@ struct MyCollectionFiltersScreenFactory: ScreenFactory {
     
     init(
         games: [SavedGame],
-        selectedFilters: [GameFilter]?,
+        gameFilterForm: GameFilterForm?,
         myCollectionDelegate: MyCollectionViewModelDelegate?
     ) {
         self.games = games
-        self.selectedFilters = selectedFilters
+        self.gameFilterForm = gameFilterForm
         self.myCollectionDelegate = myCollectionDelegate
     }
 }

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersSection.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersSection.swift
@@ -11,49 +11,28 @@ final class MyCollectionFiltersSection: Section {
     
     init(
         games: [SavedGame],
-        selectedFilters: [GameFilter]?,
+        gameFilterForm: GameFilterForm,
         formDelegate: FormDelegate
     ) {
         super.init()
         self.position = 0
         
-        var acquisitionYearFilterValue: String?
-        var conditionFilterValue: String?
-        var completenessFilterValue: String?
-        var regionFilterValue: String?
-        var storageAreaFilterValue: String?
-        var ratingFilterValue: Int?
-        
-        if let selectedFilters = selectedFilters {
-            for filter in selectedFilters {
-                switch filter {
-                case let .acquisitionYear(value):
-                    acquisitionYearFilterValue = value
-                case let .gameCondition(value):
-                    var gameConditionText: String?
-                    if let gameCondition = GameCondition(rawValue: value) {
-                        gameConditionText = gameCondition.value
-                    }
-                    conditionFilterValue = gameConditionText
-                case let .gameCompleteness(value):
-                    var gameCompletenessText: String?
-                    if let gameCompleteness = GameCompleteness(rawValue: value) {
-                        gameCompletenessText = gameCompleteness.value
-                    }
-                    completenessFilterValue = gameCompletenessText
-                case let .gameRegion(value):
-                    var gameRegionText: String?
-                    if let gameRegion = GameRegion(rawValue: value) {
-                        gameRegionText = gameRegion.value
-                    }
-                    regionFilterValue = gameRegionText
-                case let .storageArea(value):
-                    storageAreaFilterValue = value
-                case let .rating(value):
-                    ratingFilterValue = value
-                }
-            }
+        var isPhysicalValue: String?
+        if let isPhysical = gameFilterForm.isPhysical {
+            isPhysicalValue = isPhysical ? GameFormat.physical.text : GameFormat.digital.text
         }
+        
+        let isPhysicalCellVM = TextFieldCellViewModel(
+            placeholder: L10n.gameFormat,
+            formType: GameFilterFormType.isPhysical(
+                PickerViewModel(
+                    data: [[GameFormat.physical.text, GameFormat.digital.text, L10n.any]]
+                )
+            ),
+            value: isPhysicalValue,
+            formDelegate: formDelegate
+        )
+        self.cellsVM.append(isPhysicalCellVM)
         
         let acquisitionYearArray = Array(
             Set(
@@ -65,12 +44,12 @@ final class MyCollectionFiltersSection: Section {
         if !acquisitionYearArray.isEmpty {
             let yearOfAcquisitionCellVM = TextFieldCellViewModel(
                 placeholder: L10n.yearOfAcquisition,
-                formType: GameFilterFormType.yearOfAcquisition(
+                formType: GameFilterFormType.acquisitionYear(
                     PickerViewModel(
                         data: [acquisitionYearArray.sorted()]
                     )
                 ),
-                value: acquisitionYearFilterValue ?? nil,
+                value: gameFilterForm.acquisitionYear ?? nil,
                 formDelegate: formDelegate
             )
             self.cellsVM.append(yearOfAcquisitionCellVM)
@@ -88,7 +67,7 @@ final class MyCollectionFiltersSection: Section {
                     }]
                 )
             ),
-            value: conditionFilterValue ?? nil,
+            value: gameFilterForm.gameCondition?.value ?? nil,
             formDelegate: formDelegate
         )
         self.cellsVM.append(conditionCellVM)
@@ -105,7 +84,7 @@ final class MyCollectionFiltersSection: Section {
                     }]
                 )
             ),
-            value: completenessFilterValue ?? nil,
+            value: gameFilterForm.gameCompleteness?.value ?? nil,
             formDelegate: formDelegate
         )
         self.cellsVM.append(completenessCellVM)
@@ -117,7 +96,7 @@ final class MyCollectionFiltersSection: Section {
                     data: [GameRegion.allCases.map { $0.value }]
                 )
             ),
-            value: regionFilterValue ?? nil,
+            value: gameFilterForm.gameRegion?.value ?? nil,
             formDelegate: formDelegate
         )
         self.cellsVM.append(regionCellVM)
@@ -137,7 +116,7 @@ final class MyCollectionFiltersSection: Section {
                         data: [storageAreaArray.sorted()]
                     )
                 ),
-                value: storageAreaFilterValue ?? nil,
+                value: gameFilterForm.storageArea ?? nil,
                 formDelegate: formDelegate
             )
             self.cellsVM.append(storageAreaCellVM)
@@ -146,7 +125,7 @@ final class MyCollectionFiltersSection: Section {
         let personalRatingCellVM = StarRatingCellViewModel(
             title: L10n.personalRating,
             formType: GameFilterFormType.rating,
-            value: ratingFilterValue ?? nil,
+            value: gameFilterForm.rating ?? nil,
             formDelegate: formDelegate
         )
         self.cellsVM.append(personalRatingCellVM)

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
@@ -51,7 +51,7 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
                 formDelegate: self
             )]
             self.containerDelegate?.reloadSections(emptyError: nil)
-            self.configureBottomView(shouldEnableButton: false)
+            self.configureBottomView(shouldEnableButton: true)
             await self.myCollectionDelegate?.clearFilters()
         default:
             break
@@ -115,7 +115,9 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
             selectedFilters.append(GameFilter.storageArea(storageArea))
         }
         if let rating = self.gameFilterForm.rating {
-            selectedFilters.append(GameFilter.rating(rating))
+            if rating != .zero {
+                selectedFilters.append(GameFilter.rating(rating))
+            }
         }
         return selectedFilters
     }

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
@@ -21,24 +21,20 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
     weak var myCollectionDelegate: MyCollectionViewModelDelegate?
     
     private let games: [SavedGame]
-    var selectedFilters: [GameFilter]?
+    private var gameFilterForm: GameFilterForm
     
     init(
         games: [SavedGame],
-        selectedFilters: [GameFilter]?,
+        gameFilterForm: GameFilterForm?,
         myCollectionDelegate: MyCollectionViewModelDelegate?
     ) {
         self.games = games
-        self.selectedFilters = selectedFilters
+        self.gameFilterForm = gameFilterForm ?? GameFilterForm()
         self.myCollectionDelegate = myCollectionDelegate
     }
     
     func loadData(callback: @escaping (EmptyError?) -> ()) {
-        self.sections = [MyCollectionFiltersSection(
-            games: self.games,
-            selectedFilters: self.selectedFilters,
-            formDelegate: self
-        )]
+        self.updateSections()
         self.configureBottomView(shouldEnableButton: false)
         callback(nil)
     }
@@ -48,14 +44,15 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
         case .close:
             self.close()
         case .clear:
-            self.selectedFilters = []
+            self.gameFilterForm = GameFilterForm()
             self.sections = [MyCollectionFiltersSection(
                 games: self.games,
-                selectedFilters: self.selectedFilters,
+                gameFilterForm: self.gameFilterForm,
                 formDelegate: self
             )]
-            self.configureBottomView(shouldEnableButton: true)
             self.containerDelegate?.reloadSections(emptyError: nil)
+            self.configureBottomView(shouldEnableButton: false)
+            await self.myCollectionDelegate?.clearFilters()
         default:
             break
         }
@@ -80,72 +77,108 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
     }
     
     private func getFilters() -> [GameFilter] {
-        guard let firstSection = self.sections.first,
-              let formCellsVM = firstSection.cellsVM.filter({ cellVM in
-                  return cellVM is (any FormCellViewModel)
-              }) as? [any FormCellViewModel] else {
-            return []
-        }
-
         var selectedFilters = [GameFilter]()
         
-        for formCellVM in formCellsVM {
-            guard let formType = formCellVM.formType as? GameFilterFormType else { return [] }
-            switch formType {
-            case .yearOfAcquisition:
-                guard let acquisitionYear = formCellVM.value as? String else {
-                    break
-                }
-                selectedFilters.append(GameFilter.acquisitionYear(acquisitionYear))
-            case .gameCondition(_):
-                guard let conditionText = formCellVM.value as? String else {
-                    break
-                }
-                let condition = GameCondition.getRawValue(
-                    value: conditionText
-                )
-                selectedFilters.append(GameFilter.gameCondition(condition.rawValue))
-            case .gameCompleteness(_):
-                guard let completenessText = formCellVM.value as? String else {
-                    break
-                }
-                let completeness = GameCompleteness.getRawValue(
-                    value: completenessText
-                )
-                selectedFilters.append(GameFilter.gameCompleteness(completeness.rawValue))
-            case .gameRegion(_):
-                guard let regionText = formCellVM.value as? String else {
-                    break
-                }
-                let region = GameRegion.getRawValue(
-                    value: regionText
-                )
-                selectedFilters.append(GameFilter.gameRegion(region.rawValue))
-            case .storageArea:
-                guard let storageArea = formCellVM.value as? String else {
-                    break
-                }
-                selectedFilters.append(GameFilter.storageArea(storageArea))
-            case .rating:
-                guard let rating = formCellVM.value as? Int,
-                      rating != .zero else {
-                    break
-                }
-                selectedFilters.append(GameFilter.rating(rating))
-            }
+        if let isPhysical = self.gameFilterForm.isPhysical {
+            selectedFilters.append(
+                GameFilter.isPhysical(isPhysical)
+            )
+        }
+        if let acquisitionYear = self.gameFilterForm.acquisitionYear {
+            selectedFilters.append(GameFilter.acquisitionYear(acquisitionYear))
+        }
+        if let gameCondition = self.gameFilterForm.gameCondition {
+            let conditionValue = GameCondition.getRawValue(
+                value: gameCondition.value
+            )
+            selectedFilters.append(
+                GameFilter.gameCondition(conditionValue.rawValue)
+            )
+        }
+        if let gameCompleteness = self.gameFilterForm.gameCompleteness {
+            let completenessValue = GameCompleteness.getRawValue(
+                value: gameCompleteness.value
+            )
+            selectedFilters.append(
+                GameFilter.gameCompleteness(completenessValue.rawValue)
+            )
+        }
+        if let gameRegion = self.gameFilterForm.gameRegion {
+            let regionValue = GameRegion.getRawValue(
+                value: gameRegion.value
+            )
+            selectedFilters.append(
+                GameFilter.gameRegion(regionValue.rawValue)
+            )
+        }
+        if let storageArea = self.gameFilterForm.storageArea {
+            selectedFilters.append(GameFilter.storageArea(storageArea))
+        }
+        if let rating = self.gameFilterForm.rating {
+            selectedFilters.append(GameFilter.rating(rating))
         }
         return selectedFilters
     }
 }
 
 extension MyCollectionFiltersViewModel: FormDelegate {
-    func didUpdate(value: Any, for type: any FormType) {}
-    
-    func enableSaveButtonIfNeeded() {
+    func didUpdate(value: Any, for type: any FormType) {
+        guard let formType = type as? GameFilterFormType else {
+            return
+        }
+        switch formType {
+        case .acquisitionYear:
+            self.gameFilterForm.acquisitionYear = value as? String
+        case .gameCondition:
+            if let stringValue = value as? String {
+                self.gameFilterForm.gameCondition = GameCondition.getRawValue(
+                    value: stringValue
+                )
+            }
+        case .gameCompleteness:
+            if let stringValue = value as? String {
+                self.gameFilterForm.gameCompleteness = GameCompleteness.getRawValue(
+                    value: stringValue
+                )
+            }
+        case .gameRegion:
+            if let stringValue = value as? String {
+                self.gameFilterForm.gameRegion = GameRegion.getRawValue(
+                    value: stringValue
+                )
+            }
+        case .storageArea:
+            self.gameFilterForm.storageArea = value as? String
+        case .rating:
+            self.gameFilterForm.rating = value as? Int ?? .zero
+        case .isPhysical:
+            let stringValue = value as? String
+            switch stringValue {
+            case GameFormat.physical.text:
+                self.gameFilterForm.isPhysical = true
+            case GameFormat.digital.text:
+                self.gameFilterForm.isPhysical = false
+            case L10n.any:
+                self.gameFilterForm.isPhysical = nil
+            default:
+                break
+            }
+        }
         self.configureBottomView(shouldEnableButton: true)
     }
     
-    func refreshSectionsDependingOnGameFormat() {}
+    func refreshSectionsDependingOnGameFormat() {
+        self.updateSections()
+        self.containerDelegate?.reloadSections(emptyError: nil)
+    }
+    
+    func updateSections() {
+        self.sections = [MyCollectionFiltersSection(
+            games: self.games,
+            gameFilterForm: self.gameFilterForm,
+            formDelegate: self
+        )]
+    }
 }
 
 // MARK: - PrimaryButtonDelegate
@@ -154,6 +187,7 @@ extension MyCollectionFiltersViewModel: PrimaryButtonDelegate {
         let selectedFilters = self.getFilters()
         guard !selectedFilters.isEmpty else {
             await self.myCollectionDelegate?.clearFilters()
+            self.configureBottomView(shouldEnableButton: false)
             self.close()
             return
         }

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
@@ -21,7 +21,7 @@ final class MyCollectionFiltersViewModel: CollectionViewModel {
     weak var myCollectionDelegate: MyCollectionViewModelDelegate?
     
     private let games: [SavedGame]
-    private var gameFilterForm: GameFilterForm
+    var gameFilterForm: GameFilterForm
     
     init(
         games: [SavedGame],

--- a/GameDex/MyProfile/Authentication/AuthenticationSection.swift
+++ b/GameDex/MyProfile/Authentication/AuthenticationSection.swift
@@ -37,15 +37,6 @@ final class AuthenticationSection: Section {
         )
         self.cellsVM.append(passwordTextField)
         
-        let loginButtonCellVM = PrimaryButtonCellViewModel(
-            buttonViewModel: ButtonViewModel(
-                title: userHasAccount ? L10n.login : L10n.createAccount,
-                backgroundColor: .secondaryColor
-            ),
-            delegate: primaryButtonDelegate
-        )
-        self.cellsVM.append(loginButtonCellVM)
-        
         if userHasAccount {
             let forgotPasswordLabelCellVM = LabelCellViewModel(
                 text: L10n.forgotPassword,

--- a/GameDex/MyProfile/Authentication/AuthenticationViewModel.swift
+++ b/GameDex/MyProfile/Authentication/AuthenticationViewModel.swift
@@ -50,7 +50,19 @@ final class AuthenticationViewModel: CollectionViewModel {
                 }
             )
         ]
+        self.configureBottomView()
         callback(nil)
+    }
+    
+    private func configureBottomView() {
+        self.containerDelegate?.configureSupplementaryView(
+            contentViewFactory: PrimaryButtonContentViewFactory(
+                delegate: self,
+                buttonTitle: self.userHasAccount ? L10n.login : L10n.createAccount,
+                shouldEnable: true,
+                position: .bottom
+            )
+        )
     }
     
     private func didTapForgotPassword() {

--- a/GameDex/MyProfile/Login/LoginViewModel.swift
+++ b/GameDex/MyProfile/Login/LoginViewModel.swift
@@ -56,8 +56,8 @@ extension LoginViewModel: PrimaryButtonDelegate {
         
         let screenFactory =  AuthenticationScreenFactory(
             userHasAccount: userHasAccount,
-            myProfileDelegate: myProfileDelegate,
-            myCollectionDelegate: myCollectionDelegate
+            myProfileDelegate: self.myProfileDelegate,
+            myCollectionDelegate: self.myCollectionDelegate
         )
         Routing.shared.route(
             navigationStyle: .push(

--- a/GameDex/Resources/Strings.swift
+++ b/GameDex/Resources/Strings.swift
@@ -18,6 +18,8 @@ internal enum L10n {
   internal static let addBasicGameInformationDescription = L10n.tr("Localizable", "addBasicGameInformationDescription", fallback: "First, add the game title and optionnally the corresponding platform.")
   /// Add to collection
   internal static let addGameToCollection = L10n.tr("Localizable", "addGameToCollection", fallback: "Add to collection")
+  /// Any
+  internal static let any = L10n.tr("Localizable", "any", fallback: "Any")
   /// There has been an issue while fetching data.
   internal static let apiErrorDescription = L10n.tr("Localizable", "apiErrorDescription", fallback: "There has been an issue while fetching data.")
   /// Oops!
@@ -104,6 +106,8 @@ internal enum L10n {
   internal static let forgotPassword = L10n.tr("Localizable", "forgotPassword", fallback: "Forgot password?")
   /// game
   internal static let game = L10n.tr("Localizable", "game", fallback: "game")
+  /// Game format
+  internal static let gameFormat = L10n.tr("Localizable", "gameFormat", fallback: "Game format")
   /// games
   internal static let games = L10n.tr("Localizable", "games", fallback: "games")
   /// Good

--- a/GameDex/Resources/en.lproj/Localizable.strings
+++ b/GameDex/Resources/en.lproj/Localizable.strings
@@ -136,6 +136,8 @@
 "collectionToDelete" = "Collection to delete";
 "physical" = "Physical";
 "digital" = "Digital";
+"any" = "Any";
+"gameFormat" = "Game format";
 
 // Other
 "game" = "game";

--- a/GameDex/Resources/fr.lproj/Localizable.strings
+++ b/GameDex/Resources/fr.lproj/Localizable.strings
@@ -135,6 +135,8 @@
 "collectionToDelete" = "Collection à supprimer";
 "physical" = "Physique";
 "digital" = "Digital";
+"any" = "Tous";
+"gameFormat" = "Format";
 
 // Other
 "game" = "jeu";

--- a/GameDexTests/Mock/MockData.swift
+++ b/GameDexTests/Mock/MockData.swift
@@ -381,4 +381,24 @@ enum MockData {
         rating: MockData.gameForm.rating,
         notes: MockData.gameForm.notes
     )
+    
+    static let gameFilterForm = GameFilterForm(
+        isPhysical: MockData.savedGame.isPhysical,
+        acquisitionYear: MockData.savedGame.acquisitionYear,
+        gameCondition: MockData.savedGame.gameCondition,
+        gameCompleteness: MockData.savedGame.gameCompleteness,
+        gameRegion: MockData.savedGame.gameRegion,
+        storageArea: MockData.savedGame.storageArea,
+        rating: MockData.savedGame.rating
+    )
+    
+    static let digitalGameFilterForm = GameFilterForm(
+        isPhysical: false,
+        acquisitionYear: MockData.savedGame.acquisitionYear,
+        gameCondition: MockData.savedGame.gameCondition,
+        gameCompleteness: MockData.savedGame.gameCompleteness,
+        gameRegion: MockData.savedGame.gameRegion,
+        storageArea: MockData.savedGame.storageArea,
+        rating: MockData.savedGame.rating
+    )
 }

--- a/GameDexTests/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformViewModelTests.swift
+++ b/GameDexTests/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformViewModelTests.swift
@@ -795,7 +795,7 @@ final class MyCollectionByPlatformViewModelTests: XCTestCase {
             return .present(
                 screenFactory: MyCollectionFiltersScreenFactory(
                     games: MockData.savedGames,
-                    selectedFilters: nil,
+                    gameFilterForm: nil,
                     myCollectionDelegate: viewModel
                 ),
                 completionBlock: nil

--- a/GameDexTests/MyCollection/MyCollectionFilters/MyCollectionFiltersSectionTests.swift
+++ b/GameDexTests/MyCollection/MyCollectionFilters/MyCollectionFiltersSectionTests.swift
@@ -10,17 +10,17 @@ import XCTest
 
 final class MyCollectionFiltersSectionTests: XCTestCase {
     
-    func test_initWithoutFilters_ThenShouldSetPropertiesCorrectly() {
+    func test_init_ThenShouldSetPropertiesCorrectly() {
         // Given
         let editFormDelegate = FormDelegateMock()
         let section = MyCollectionFiltersSection(
             games: MockData.savedGames,
-            selectedFilters: nil,
+            gameFilterForm: MockData.gameFilterForm,
             formDelegate: editFormDelegate
         )
         
         // Then
-        XCTAssertEqual(section.cellsVM.count, 6)
+        XCTAssertEqual(section.cellsVM.count, 7)
         
         guard let formCellsVM = section.cellsVM.filter({ cellVM in
             return cellVM is (any FormCellViewModel)
@@ -34,13 +34,14 @@ final class MyCollectionFiltersSectionTests: XCTestCase {
                 return
             }
             switch formType {
-            case .yearOfAcquisition:
+            case .acquisitionYear:
                 guard let acquisitionYearCellVM = formCellVM as? TextFieldCellViewModel,
                       let acquisitionYearCellVMFormType = acquisitionYearCellVM.formType as? GameFilterFormType else {
                     XCTFail("Wrong type")
                     return
                 }
                 XCTAssertEqual(acquisitionYearCellVM.placeholder, L10n.yearOfAcquisition)
+                XCTAssertEqual(acquisitionYearCellVM.value, MockData.savedGame.acquisitionYear)
                 var expectedData = [String]()
                 for item in MockData.savedGames {
                     if let data = item.acquisitionYear {
@@ -49,142 +50,7 @@ final class MyCollectionFiltersSectionTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     acquisitionYearCellVMFormType,
-                    .yearOfAcquisition(
-                        PickerViewModel(
-                            data: [expectedData.sorted()]
-                        )
-                    )
-                )
-            case .gameCondition(_):
-                guard let gameConditionCellVM = formCellVM as? TextFieldCellViewModel,
-                      let gameConditionCellVMFormType = gameConditionCellVM.formType as? GameFilterFormType else {
-                    XCTFail("Wrong type")
-                    return
-                }
-                XCTAssertEqual(gameConditionCellVM.placeholder, L10n.condition)
-                XCTAssertEqual(
-                    gameConditionCellVMFormType,
-                    .gameCondition(
-                        PickerViewModel(
-                            data: [GameCondition.allCases.compactMap {
-                                guard $0 != .unknown else {
-                                    return nil
-                                }
-                                return $0.value
-                            }]
-                        )
-                    )
-                )
-            case .gameCompleteness(_):
-                guard let gameCompletenessCellVM = formCellVM as? TextFieldCellViewModel,
-                      let gameCompletenessCellVMFormType = gameCompletenessCellVM.formType as? GameFilterFormType  else {
-                    XCTFail("Wrong type")
-                    return
-                }
-                XCTAssertEqual(gameCompletenessCellVM.placeholder, L10n.completeness)
-                XCTAssertEqual(
-                    gameCompletenessCellVMFormType,
-                    .gameCompleteness(
-                        PickerViewModel(
-                            data: [GameCompleteness.allCases.compactMap {
-                                guard $0 != .unknown else {
-                                    return nil
-                                }
-                                return $0.value
-                            }]
-                        )
-                    )
-                )
-            case .gameRegion(_):
-                guard let gameRegionCellVM = formCellVM as? TextFieldCellViewModel,
-                      let gameRegionCellVMFormType = gameRegionCellVM.formType as? GameFilterFormType else {
-                    XCTFail("Wrong type")
-                    return
-                }
-                XCTAssertEqual(gameRegionCellVM.placeholder, L10n.region)
-                XCTAssertEqual(
-                    gameRegionCellVMFormType,
-                    .gameRegion(
-                        PickerViewModel(
-                            data: [GameRegion.allCases.map { $0.value }]
-                        )
-                    )
-                )
-            case .storageArea:
-                guard let storageAreaCellVM = formCellVM as? TextFieldCellViewModel,
-                      let storageAreaCellVMFormType = storageAreaCellVM.formType as? GameFilterFormType else {
-                    XCTFail("Wrong type")
-                    return
-                }
-                XCTAssertEqual(storageAreaCellVM.placeholder, L10n.storageArea)
-                
-                var expectedData = [String]()
-                for item in MockData.savedGames {
-                    if let data = item.storageArea {
-                        expectedData.append(data)
-                    }
-                }
-                XCTAssertEqual(
-                    storageAreaCellVMFormType,
-                    .storageArea(
-                        PickerViewModel(
-                            data: [Array(Set(expectedData.sorted()))]
-                        )
-                    )
-                )
-            case .rating:
-                guard let ratingCellVM = formCellVM as? StarRatingCellViewModel else {
-                    XCTFail("Wrong type")
-                    return
-                }
-                XCTAssertEqual(ratingCellVM.title, L10n.personalRating)
-            default:
-                break
-            }
-        }
-    }
-    
-    func test_initWithFilters_ThenShouldSetPropertiesCorrectly() {
-        // Given
-        let editFormDelegate = FormDelegateMock()
-        let section = MyCollectionFiltersSection(
-            games: MockData.savedGames,
-            selectedFilters: MockData.gameFiltersWithMatchingGames,
-            formDelegate: editFormDelegate
-        )
-        
-        // Then
-        XCTAssertEqual(section.cellsVM.count, 6)
-        
-        guard let formCellsVM = section.cellsVM.filter({ cellVM in
-            return cellVM is (any FormCellViewModel)
-        }) as? [any FormCellViewModel] else {
-            return
-        }
-        
-        for formCellVM in formCellsVM {
-            guard let formType = formCellVM.formType as? GameFilterFormType else {
-                XCTFail("Wrong type")
-                return
-            }
-            switch formType {
-            case .yearOfAcquisition:
-                guard let acquisitionYearCellVM = formCellVM as? TextFieldCellViewModel,
-                      let acquisitionYearCellVMFormType = acquisitionYearCellVM.formType as? GameFilterFormType else {
-                    XCTFail("Wrong type")
-                    return
-                }
-                XCTAssertEqual(acquisitionYearCellVM.placeholder, L10n.yearOfAcquisition)
-                XCTAssertEqual(acquisitionYearCellVM.value, nil)
-                var expectedData = [String]()
-                for item in MockData.savedGames {
-                    if let data = item.acquisitionYear {
-                        expectedData.append(data)
-                    }
-                }
-                XCTAssertEqual(
-                    acquisitionYearCellVMFormType,
-                    .yearOfAcquisition(
+                    .acquisitionYear(
                         PickerViewModel(
                             data: [expectedData.sorted()]
                         )
@@ -257,7 +123,7 @@ final class MyCollectionFiltersSectionTests: XCTestCase {
                     return
                 }
                 XCTAssertEqual(storageAreaCellVM.placeholder, L10n.storageArea)
-                XCTAssertEqual(storageAreaCellVM.value, nil)
+                XCTAssertEqual(storageAreaCellVM.value, MockData.savedGame.storageArea)
                 var expectedData = [String]()
                 for item in MockData.savedGames {
                     if let data = item.storageArea {
@@ -277,10 +143,15 @@ final class MyCollectionFiltersSectionTests: XCTestCase {
                     XCTFail("Wrong type")
                     return
                 }
-                XCTAssertEqual(ratingCellVM.value, nil)
+                XCTAssertEqual(ratingCellVM.value, MockData.savedGame.rating)
                 XCTAssertEqual(ratingCellVM.title, L10n.personalRating)
-            default:
-                break
+            case .isPhysical:
+                guard let isPhysicalCellVM = formCellVM as? TextFieldCellViewModel else {
+                    XCTFail("Wrong type")
+                    return
+                }
+                XCTAssertEqual(isPhysicalCellVM.value, L10n.physical)
+                XCTAssertEqual(isPhysicalCellVM.placeholder, L10n.gameFormat)
             }
         }
     }

--- a/GameDexTests/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModelTests.swift
+++ b/GameDexTests/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModelTests.swift
@@ -17,7 +17,7 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         // Given
         let viewModel = MyCollectionFiltersViewModel(
             games: MockData.savedGames,
-            selectedFilters: nil,
+            gameFilterForm: nil,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
         // When
@@ -33,7 +33,7 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         let containerDelegate = ContainerViewControllerDelegateMock()
         let viewModel = MyCollectionFiltersViewModel(
             games: MockData.savedGames,
-            selectedFilters: nil,
+            gameFilterForm: nil,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
         viewModel.containerDelegate = containerDelegate
@@ -47,7 +47,7 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(callbackIsCalled)
         XCTAssertEqual(viewModel.numberOfSections(), 1)
-        XCTAssertEqual(viewModel.numberOfItems(in: .zero), 6)
+        XCTAssertEqual(viewModel.numberOfItems(in: .zero), 7)
         containerDelegate.verify(.configureSupplementaryView(contentViewFactory: .any), count: .once)
     }
     
@@ -56,7 +56,7 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         let myCollectionDelegate = MyCollectionViewModelDelegateMock()
         let viewModel = MyCollectionFiltersViewModel(
             games: MockData.savedGames,
-            selectedFilters: nil,
+            gameFilterForm: nil,
             myCollectionDelegate: myCollectionDelegate
         )
         viewModel.loadData { _ in }
@@ -75,7 +75,7 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         let containerDelegate = ContainerViewControllerDelegateMock()
         let viewModel = MyCollectionFiltersViewModel(
             games: MockData.savedGames,
-            selectedFilters: MockData.gameFiltersWithMatchingGames,
+            gameFilterForm: MockData.gameFilterForm,
             myCollectionDelegate: myCollectionDelegate
         )
         viewModel.containerDelegate = containerDelegate
@@ -89,33 +89,11 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         XCTAssertEqual(Routing.shared.lastNavigationStyle, .dismiss(completionBlock: nil))
     }
     
-    func test_enableSaveButtonIfNeeded_ThenConfigureBottomView() {
-        // Given
-        let containerDelegate = ContainerViewControllerDelegateMock()
-        let viewModel = MyCollectionFiltersViewModel(
-            games: MockData.savedGames,
-            selectedFilters: MockData.gameFiltersWithMatchingGames,
-            myCollectionDelegate: MyCollectionViewModelDelegateMock()
-        )
-        viewModel.containerDelegate = containerDelegate
-        viewModel.loadData { _ in }
-        
-        // When
-        viewModel.enableSaveButtonIfNeeded()
-        
-        // Then
-        containerDelegate.verify(
-            .configureSupplementaryView(
-                contentViewFactory: .any
-            ), count: 2
-        )
-    }
-    
     func test_didTapCloseButtonItem_ThenViewShouldBeDismissed() async {
         // Given
         let viewModel = MyCollectionFiltersViewModel(
             games: MockData.savedGames,
-            selectedFilters: MockData.gameFiltersWithMatchingGames,
+            gameFilterForm: MockData.gameFilterForm,
             myCollectionDelegate: MyCollectionViewModelDelegateMock()
         )
         viewModel.loadData { _ in }
@@ -133,7 +111,7 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         let containerDelegate = ContainerViewControllerDelegateMock()
         let viewModel = MyCollectionFiltersViewModel(
             games: MockData.savedGames,
-            selectedFilters: MockData.gameFiltersWithMatchingGames,
+            gameFilterForm: MockData.gameFilterForm,
             myCollectionDelegate: myCollectionDelegate
         )
         viewModel.containerDelegate = containerDelegate
@@ -144,5 +122,99 @@ final class MyCollectionFiltersViewModelTests: XCTestCase {
         
         // Then
         containerDelegate.verify(.configureSupplementaryView(contentViewFactory: .any), count: 2)
+    }
+    
+    func test_didUpdate_ThenSetsGameFilterFormCorrectly() {
+        // GIVEN
+        let viewModel = MyCollectionFiltersViewModel(
+            games: MockData.savedGames,
+            gameFilterForm: MockData.digitalGameFilterForm,
+            myCollectionDelegate: MyCollectionViewModelDelegateMock()
+        )
+        viewModel.loadData { _ in }
+        
+        // WHEN
+        var acquisitionYearArea = [String]()
+        for item in MockData.savedGames {
+            if let data = item.acquisitionYear {
+                acquisitionYearArea.append(data)
+            }
+        }
+        viewModel.didUpdate(
+            value: MockData.gameFilterForm.acquisitionYear as Any,
+            for: GameFilterFormType.acquisitionYear(
+                PickerViewModel(
+                    data: [acquisitionYearArea]
+                )
+            )
+        )
+        viewModel.didUpdate(
+            value: MockData.gameFilterForm.gameCondition as Any,
+            for: GameFilterFormType.gameCondition(
+                PickerViewModel(
+                    data: [GameCondition.allCases.compactMap {
+                        guard $0 != .unknown else {
+                            return nil
+                        }
+                        return $0.value
+                    }]
+                )
+            )
+        )
+        viewModel.didUpdate(
+            value: MockData.gameFilterForm.gameCompleteness as Any,
+            for: GameFilterFormType.gameCompleteness(
+                PickerViewModel(
+                    data: [GameCompleteness.allCases.compactMap {
+                        guard $0 != .unknown else {
+                            return nil
+                        }
+                        return $0.value
+                    }]
+                )
+            )
+        )
+        viewModel.didUpdate(
+            value: MockData.gameFilterForm.gameRegion as Any,
+            for: GameFilterFormType.gameRegion(
+                PickerViewModel(
+                    data: [GameRegion.allCases.map { $0.value }]
+                )
+            )
+        )
+        viewModel.didUpdate(value: MockData.gameFilterForm.rating as Any, for: GameFilterFormType.rating)
+        
+        var storageAreaArray = [String]()
+        for item in MockData.savedGames {
+            if let data = item.storageArea {
+                storageAreaArray.append(data)
+            }
+        }
+        viewModel.didUpdate(
+            value: MockData.gameFilterForm.storageArea as Any,
+            for: GameFilterFormType.storageArea(
+                PickerViewModel(
+                    data: [storageAreaArray]
+                )
+            )
+        )
+        
+        let gameFormatArray = [L10n.physical, L10n.digital, L10n.any]
+        viewModel.didUpdate(
+            value: MockData.gameFilterForm.isPhysical as Any,
+            for: GameFilterFormType.isPhysical(
+                PickerViewModel(
+                    data: [gameFormatArray]
+                )
+            )
+        )
+        
+        // THEN
+        XCTAssertEqual(viewModel.gameFilterForm.acquisitionYear, MockData.gameFilterForm.acquisitionYear)
+        XCTAssertEqual(viewModel.gameFilterForm.gameCompleteness, MockData.gameFilterForm.gameCompleteness)
+        XCTAssertEqual(viewModel.gameFilterForm.gameCondition, MockData.gameFilterForm.gameCondition)
+        XCTAssertEqual(viewModel.gameFilterForm.gameRegion, MockData.gameFilterForm.gameRegion)
+        XCTAssertEqual(viewModel.gameFilterForm.storageArea, MockData.gameFilterForm.storageArea)
+        XCTAssertEqual(viewModel.gameFilterForm.rating, MockData.gameFilterForm.rating)
     }
 }

--- a/PlatformCollected.swift
+++ b/PlatformCollected.swift
@@ -21,11 +21,8 @@ public class PlatformCollected: NSManagedObject {
     @NSManaged public var supportedNames: NSSet
 
     public var gamesArray: [GameCollected] {
-        let set = games as? Set<GameCollected> ?? []
-        
-        return set.sorted {
-            $0.title < $1.title
-        }
+        var array = games?.allObjects as? [GameCollected] ?? []
+        return array
     }
     
     public var supportedNamesArray: [PlatformSupportedNames] {

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,6 @@ target 'GameDex' do
   pod 'EmptyDataSet-Swift', '~> 5.0.0', :inhibit_warnings => true
   pod 'NVActivityIndicatorView', :inhibit_warnings => true
   pod 'DTTextField', :inhibit_warnings => true
-  pod 'IQKeyboardManagerSwift', '~> 6.5.0', :inhibit_warnings => true
   pod "SwiftyMocky", :inhibit_warnings => true
   pod 'Alamofire', :inhibit_warnings => true
   pod 'SDWebImage', :inhibit_warnings => true

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -772,7 +772,6 @@ PODS:
     - gRPC-Core/Interface (= 1.50.1)
   - gRPC-Core/Interface (1.50.1)
   - GTMSessionFetcher/Core (3.1.1)
-  - IQKeyboardManagerSwift (6.5.12)
   - leveldb-library (1.22.2)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
@@ -807,7 +806,6 @@ DEPENDENCIES:
   - FirebaseAuth
   - FirebaseCrashlytics
   - FirebaseFirestore
-  - IQKeyboardManagerSwift (~> 6.5.0)
   - NVActivityIndicatorView
   - ReachabilitySwift
   - SDWebImage
@@ -840,7 +838,6 @@ SPEC REPOS:
     - "gRPC-C++"
     - gRPC-Core
     - GTMSessionFetcher
-    - IQKeyboardManagerSwift
     - leveldb-library
     - nanopb
     - NVActivityIndicatorView
@@ -887,7 +884,6 @@ SPEC CHECKSUMS:
   "gRPC-C++": 0968bace703459fd3e5dcb0b2bed4c573dbff046
   gRPC-Core: 17108291d84332196d3c8466b48f016fc17d816d
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
-  IQKeyboardManagerSwift: 371b08cb39664fb56030f5345c815a4ffc74bbc0
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   NVActivityIndicatorView: 1f6c5687f1171810aa27a3296814dc2d7dec3667
@@ -903,6 +899,6 @@ SPEC CHECKSUMS:
   SwiftyMocky: 014739247afadb65efb5bb92ede32c22b9365762
   SwiftyTextView: be873b6b426d148fef9e2a341b3c5989b167572b
 
-PODFILE CHECKSUM: b01aac69aa36591b99000305613b347faa4fe48c
+PODFILE CHECKSUM: d79a0213c72efb5d17e7b74b72516deb1f1ebcbb
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
We added the possibility to filter user games on game format (physical/digital/any).

**In more details :** 
- Creation of GameFilterForm to save values selected for filters
- Use of a PickerView to display options (Physical / Digital / Any)
- If user selects Digital game format and has also selected a game condition / completeness / region or storage area, the mentioned last four fields will not be taken into account when filtering games as digital games cannot have such options associated.


| Filtering options light mode  | Filtering options dark mode  | Game format Picker light mode  | Game format Picker dark mode  |
|---|---|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-06 at 15 56 39](https://github.com/RabiosStudio/GameDex/assets/117658161/1802a9cc-445a-49de-bc80-198ac493388c)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-06 at 15 56 37](https://github.com/RabiosStudio/GameDex/assets/117658161/50defaf6-d1dd-4502-9008-03db39ed5e1b)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-06 at 15 56 42](https://github.com/RabiosStudio/GameDex/assets/117658161/b60f1b4f-2373-4f45-ac51-f6246df03e6b)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-06 at 15 56 44](https://github.com/RabiosStudio/GameDex/assets/117658161/db5d8089-fe4c-42fc-9a4a-470036b260b2)  |
