### PR TITLE
Feature/keep pull to refresh only when needed

### DIFF
--- a/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleViewModel.swift
+++ b/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleViewModel.swift
@@ -16,6 +16,7 @@ final class SearchGameByTitleViewModel: CollectionViewModel {
         delegate: self
     )
     var isBounceable: Bool = true
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]? = [.close]
     let screenTitle: String? = L10n.searchGame

--- a/GameDex/AddGame/SelectPlatform/SelectPlatformViewModel.swift
+++ b/GameDex/AddGame/SelectPlatform/SelectPlatformViewModel.swift
@@ -16,6 +16,7 @@ final class SelectPlatformViewModel: CollectionViewModel {
         delegate: self
     )
     var isBounceable: Bool = true
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]? = [.close]
     let screenTitle: String? = L10n.searchPlatform

--- a/GameDex/Common/Controllers/ContainerViewController.swift
+++ b/GameDex/Common/Controllers/ContainerViewController.swift
@@ -26,7 +26,6 @@ class ContainerViewController: UIViewController {
     private let layout: UICollectionViewLayout
     private lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: #selector(loadData), for: .valueChanged)
         return refreshControl
     }()
     
@@ -145,6 +144,7 @@ class ContainerViewController: UIViewController {
                             tabBarOffset: tabBarOffset
                         )
                         strongSelf.configureNavBar()
+                        strongSelf.configureRefreshControl()
                         if let searchVM = strongSelf.viewModel.searchViewModel, searchVM.alwaysShow {
                             strongSelf.configureSearchBar()
                         } else {
@@ -289,9 +289,6 @@ class ContainerViewController: UIViewController {
         // Keyboard animation
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardAnimation), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardAnimation), name: UIResponder.keyboardWillHideNotification, object: nil)
-        
-        // Call loadData when app enters foreground
-        NotificationCenter.default.addObserver(self, selector: #selector(loadData), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
     @objc private func handleKeyboardAnimation(notification: NSNotification) {
@@ -333,12 +330,19 @@ class ContainerViewController: UIViewController {
         )
     }
     
+    private func configureRefreshControl() {
+        if self.viewModel.isRefreshable {
+            self.collectionView.addSubview(self.refreshControl)
+            self.refreshControl.addTarget(self, action: #selector(loadData), for: .valueChanged)
+        }
+    }
+    
     private func setupContent() {
         self.registerCells()
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
         self.collectionView.alwaysBounceVertical = self.viewModel.isBounceable
-        self.collectionView.addSubview(self.refreshControl)
+        self.configureRefreshControl()
         self.stackView.addArrangedSubview(self.collectionView)
         self.view.addSubview(stackView)
         self.setupStackViewConstraints()

--- a/GameDex/GameDetails/GameDetailsViewModel.swift
+++ b/GameDex/GameDetails/GameDetailsViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class GameDetailsViewModel: CollectionViewModel {
     var searchViewModel: SearchViewModel?
     var isBounceable: Bool = true
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]?
     let screenTitle: String?

--- a/GameDex/Helpers/Protocols/CollectionViewModel.swift
+++ b/GameDex/Helpers/Protocols/CollectionViewModel.swift
@@ -12,6 +12,7 @@ protocol CollectionViewModel {
     var screenTitle: String? { get }
     var buttonItems: [AnyBarButtonItem]? { get }
     var isBounceable: Bool { get }
+    var isRefreshable: Bool { get }
     var searchViewModel: SearchViewModel? { get }
     var sections: [Section] { get }
     var progress: Float? { get }

--- a/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsViewModel.swift
@@ -16,6 +16,7 @@ final class MyCollectionByPlatformsViewModel: ConnectivityDisplayerViewModel {
         delegate: self
     )
     var isBounceable: Bool = true
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]?
     let screenTitle: String?

--- a/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionFilters/MyCollectionFiltersViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class MyCollectionFiltersViewModel: CollectionViewModel {
     var searchViewModel: SearchViewModel?
     var isBounceable: Bool = true
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]? = [.close, .clear]
     let screenTitle: String? = L10n.filters

--- a/GameDex/MyCollection/MyCollectionOverview/MyCollectionViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionOverview/MyCollectionViewModel.swift
@@ -23,6 +23,7 @@ final class MyCollectionViewModel: ConnectivityDisplayerViewModel {
         delegate: self
     )
     var isBounceable: Bool = true
+    var isRefreshable: Bool = true
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]? = [.add]
     let screenTitle: String? = L10n.myCollection

--- a/GameDex/MyProfile/Authentication/AuthenticationViewModel.swift
+++ b/GameDex/MyProfile/Authentication/AuthenticationViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class AuthenticationViewModel: CollectionViewModel {
     var searchViewModel: SearchViewModel?
     var isBounceable: Bool = false
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]?
     let screenTitle: String?

--- a/GameDex/MyProfile/CollectionManagement/CollectionManagementViewModel.swift
+++ b/GameDex/MyProfile/CollectionManagement/CollectionManagementViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class CollectionManagementViewModel: CollectionViewModel {
     var searchViewModel: SearchViewModel?
     var isBounceable: Bool = false
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]?
     let screenTitle: String? = L10n.collectionManagement

--- a/GameDex/MyProfile/EditProfile/EditProfileViewModel.swift
+++ b/GameDex/MyProfile/EditProfile/EditProfileViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class EditProfileViewModel: CollectionViewModel {
     var searchViewModel: SearchViewModel?
     var isBounceable: Bool = false
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]?
     let screenTitle: String? = L10n.editProfile

--- a/GameDex/MyProfile/Login/LoginViewModel.swift
+++ b/GameDex/MyProfile/Login/LoginViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 final class LoginViewModel: CollectionViewModel {
     var searchViewModel: SearchViewModel?
     var isBounceable: Bool = false
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]?
     let screenTitle: String? = L10n.login

--- a/GameDex/MyProfile/MyProfileViewModel.swift
+++ b/GameDex/MyProfile/MyProfileViewModel.swift
@@ -16,6 +16,7 @@ protocol MyProfileViewModelDelegate: AnyObject {
 final class MyProfileViewModel: CollectionViewModel {
     var searchViewModel: SearchViewModel?
     var isBounceable: Bool = true
+    var isRefreshable: Bool = false
     var progress: Float?
     var buttonItems: [AnyBarButtonItem]?
     let screenTitle: String? = L10n.myProfile


### PR DESCRIPTION
**What changed :**
The pull to refresh was set on every screen but it is only needed on the main collection so we removed it on other screens.

**In more details :** 
- we added a boolean property isRefreshable to protocol CollectionViewModel
- isRefreshable is set to false for all viewModels but MyCollectionViewModel
- we added a method configureRefreshControl() to setup refreshControl on collectionView with target loadData()
