### PR TITLE
remove trailing whitespaces before starting search

### DIFF
--- a/GameDex/Common/Controllers/ContainerViewController.swift
+++ b/GameDex/Common/Controllers/ContainerViewController.swift
@@ -447,20 +447,24 @@ extension ContainerViewController: UISearchBarDelegate {
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        guard let searchQuery = searchBar.text else {
+        guard let searchText = searchBar.text else {
             return
         }
+        let searchQuery = searchText.removeTrailingWhitespace()
         self.searchBar.endEditing(true)
         self.configureLoader()
         self.viewModel.searchViewModel?.delegate?.startSearch(
             from: searchQuery) { [weak self] error in
                 self?.reloadSections(emptyError: error)
+                DispatchQueue.main.async {
+                    self?.searchBar.text = searchQuery
+                }
             }
     }
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         // called when text changes (including clear)
-        self.viewModel.searchViewModel?.delegate?.updateSearchTextField(with: searchText) { [weak self] error in
+        self.viewModel.searchViewModel?.delegate?.updateSearchTextField(with: searchText.removeTrailingWhitespace()) { [weak self] error in
             self?.reloadSections(emptyError: error)
         }
     }

--- a/GameDex/DesignSystem/String+Extension.swift
+++ b/GameDex/DesignSystem/String+Extension.swift
@@ -11,4 +11,12 @@ extension String {
     func removeWhiteSpaces() -> String {
         return self.replacingOccurrences(of: " ", with: "")
     }
+    
+    func removeTrailingWhitespace() -> String {
+        if let trailingWhitespaces = self.range(of: "\\s+$", options: .regularExpression) {
+            return self.replacingCharacters(in: trailingWhitespaces, with: "")
+        } else {
+            return self
+        }
+    }
 }


### PR DESCRIPTION
**What changed**
we added a new method to remove all trailing whitespaces in a String
use this method before starting a search
update searchText when search is finished without trailing whitespaces