### PR TITLE
remove image and tabBarOffset on most empty screens

### DIFF
--- a/GameDex/AddGame/AddGameError.swift
+++ b/GameDex/AddGame/AddGameError.swift
@@ -37,7 +37,7 @@ enum AddGameError: EmptyError {
     var imageName: String? {
         switch self {
         case .noItems:
-            return Asset.noItems.name
+            return nil
         case .server:
             return Asset.exclamationMark.name
         case .noSearch:

--- a/GameDex/Common/Controllers/ContainerViewController.swift
+++ b/GameDex/Common/Controllers/ContainerViewController.swift
@@ -138,11 +138,7 @@ class ContainerViewController: UIViewController {
                 DispatchQueue.main.async {
                     guard let strongSelf = self else { return }
                     if let error = error {
-                        let tabBarOffset = -(self?.tabBarController?.tabBar.frame.size.height ?? 0)
-                        strongSelf.updateEmptyState(
-                            error: error,
-                            tabBarOffset: tabBarOffset
-                        )
+                        strongSelf.updateEmptyState(error: error)
                         strongSelf.configureNavBar()
                         strongSelf.configureRefreshControl()
                         if let searchVM = strongSelf.viewModel.searchViewModel, searchVM.alwaysShow {
@@ -171,18 +167,18 @@ class ContainerViewController: UIViewController {
         self.collectionView.reloadData()
     }
     
-    private func updateEmptyState(error: EmptyError?, tabBarOffset: CGFloat) {
+    private func updateEmptyState(error: EmptyError?) {
         DispatchQueue.main.async {
             if let error = error {
-                guard let imageName = error.imageName,
-                      let image = UIImage(named: imageName) else {
-                    return
+                var image: UIImage?
+                if let imageName = error.imageName {
+                    image = UIImage(named: imageName)
                 }
+                let resizedImage = image?.resized(toWidth: DesignSystem.sizeSmall, isOpaque: false)
                 let emptyReason = EmptyTextAndButton(
-                    tabBarOffset: tabBarOffset,
                     customTitle: error.errorTitle,
                     descriptionText: error.errorDescription,
-                    image: image,
+                    image: resizedImage,
                     buttonTitle: error.buttonTitle
                 ) {
                     switch error.errorAction {
@@ -279,9 +275,7 @@ class ContainerViewController: UIViewController {
     }
     
     private func configureLoader() {
-        let tabBarOffset = -(self.tabBarController?.tabBar.frame.size.height ?? 0)
-        let emptyLoader = EmptyLoader(tabBarOffset: tabBarOffset)
-        self.collectionView.updateEmptyScreen(emptyReason: emptyLoader)
+        self.collectionView.updateEmptyScreen(emptyReason: EmptyLoader())
         self.collectionView.reloadEmptyDataSet()
     }
     
@@ -508,8 +502,7 @@ extension ContainerViewController: ContainerViewControllerDelegate {
     func reloadSections(emptyError: EmptyError?) {
         DispatchQueue.main.async {
             if let error = emptyError {
-                let tabBarOffset = -(self.tabBarController?.tabBar.frame.size.height ?? 0)
-                self.updateEmptyState(error: error, tabBarOffset: tabBarOffset)
+                self.updateEmptyState(error: error)
             } else {
                 self.reloadCollectionView()
             }

--- a/GameDex/DesignSystem/UIImageView+Extension.swift
+++ b/GameDex/DesignSystem/UIImageView+Extension.swift
@@ -23,3 +23,13 @@ extension UIImageView {
         }
     }
 }
+
+extension UIImage {
+    func resized(toWidth width: CGFloat, isOpaque: Bool = true) -> UIImage? {
+        let canvas = CGSize(width: width, height: CGFloat(ceil(width/size.width * size.height)))
+        let format = imageRendererFormat
+        format.opaque = isOpaque
+        return UIGraphicsImageRenderer(size: canvas, format: format).image { _ in draw(in: CGRect(origin: .zero, size: canvas))
+        }
+    }
+}

--- a/GameDex/Helpers/EmptyScreens/EmptyLoader.swift
+++ b/GameDex/Helpers/EmptyScreens/EmptyLoader.swift
@@ -13,7 +13,7 @@ struct EmptyLoader: EmptyReason {
     var completionBlock: (() -> Void)?
     
     var verticalOffset: CGFloat {
-        return tabBarOffset
+        return .zero
     }
     
     var customView: UIView? {
@@ -23,11 +23,5 @@ struct EmptyLoader: EmptyReason {
                                            padding: 16)
         view.startAnimating()
         return view
-    }
-    
-    let tabBarOffset: CGFloat
-    
-    init(tabBarOffset: CGFloat) {
-        self.tabBarOffset = tabBarOffset
     }
 }

--- a/GameDex/Helpers/EmptyScreens/EmptyTextAndButton.swift
+++ b/GameDex/Helpers/EmptyScreens/EmptyTextAndButton.swift
@@ -10,10 +10,8 @@ import UIKit
 struct EmptyTextAndButton: EmptyReason {
     // Vertical Offset
     var verticalOffset: CGFloat {
-        return tabBarOffset
+        return .zero
     }
-    
-    let tabBarOffset: CGFloat
     
     // Title
     let customTitle: String?
@@ -60,13 +58,13 @@ struct EmptyTextAndButton: EmptyReason {
     
     let buttonTitle: String?
     
-    init(tabBarOffset: CGFloat,
-         customTitle: String?,
-         descriptionText: String?,
-         image: UIImage?,
-         buttonTitle: String?,
-         completionBlock: (() -> Void)? ) {
-        self.tabBarOffset = tabBarOffset
+    init(
+        customTitle: String?,
+        descriptionText: String?,
+        image: UIImage?,
+        buttonTitle: String?,
+        completionBlock: (() -> Void)?
+    ) {
         self.customTitle = customTitle
         self.descriptionText = descriptionText
         self.image = image

--- a/GameDex/MyCollection/MyCollectionError.swift
+++ b/GameDex/MyCollection/MyCollectionError.swift
@@ -42,7 +42,7 @@ enum MyCollectionError: EmptyError {
         case .fetchError:
             return Asset.exclamationMark.name
         case .noItems:
-            return Asset.noItems.name
+            return nil
         }
     }
     

--- a/GameDex/MyCollection/MyCollectionOverview/MyCollectionViewModel.swift
+++ b/GameDex/MyCollection/MyCollectionOverview/MyCollectionViewModel.swift
@@ -153,7 +153,9 @@ extension MyCollectionViewModel: MyCollectionViewModelDelegate {
     
     func apply(filters: [GameFilter]) async {}
 
-    func clearFilters() {}
+    func clearFilters() {
+        self.containerDelegate?.reloadData()
+    }
 }
 
 // MARK: - SearchViewModelDelegate


### PR DESCRIPTION
**What changed :** 
It was more complicated than anticipated to resize the empty screen using the pod EmptyDataSet so we instead removed or resized the image for most empty screens (leaving only search game screen empty image).

**In more details :** 
- we removed the image name for some empty reasons
- we added a method to resize images (to reduce size of remaining images in empty screens)
- we removed the parameter tabBarOffset used in empty state settings as it is useless now