### PR TITLE
Feature/make basic info cell size different depending on screens

### DIFF
--- a/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleSection.swift
+++ b/GameDex/AddGame/SearchGameByTitle/SearchGameByTitleSection.swift
@@ -23,6 +23,7 @@ final class SearchGameByTitleSection: Section {
                 subtitle1: platform.title,
                 subtitle2: game.formattedReleaseDate,
                 caption: game.imageUrl,
+                size: .regular,
                 cellTappedCallback: {
                     let screenFactory = GameDetailsScreenFactory(
                         gameDetailsContext: .add(game: game),

--- a/GameDex/AddGame/SelectPlatform/SelectPlatformSection.swift
+++ b/GameDex/AddGame/SelectPlatform/SelectPlatformSection.swift
@@ -17,6 +17,7 @@ final class SelectPlatformSection: Section {
             let platformCellVM = BasicInfoCellViewModel(
                 title: platform.title,
                 caption: platform.imageUrl,
+                size: .small,
                 cellTappedCallback: {
                     let screenFactory = SearchGameByTitleScreenFactory(
                         platform: platform, 

--- a/GameDex/Common/Cells/BasicInfoCell.swift
+++ b/GameDex/Common/Cells/BasicInfoCell.swift
@@ -34,6 +34,8 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
         label.textColor = .secondaryColor
         label.textAlignment = .left
         label.numberOfLines = .zero
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
     
@@ -41,6 +43,8 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
         let label = VerticallyAlignedUILabel()
         label.font = Typography.body.font
         label.textColor = .secondaryColor
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
     
@@ -49,6 +53,8 @@ final class BasicInfoCell: UICollectionViewCell, CellConfigurable {
         label.font = Typography.body.font
         label.textColor = .secondaryColor
         label.numberOfLines = .zero
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
     

--- a/GameDex/Common/CellsViewModel/BasicInfoCellViewModel.swift
+++ b/GameDex/Common/CellsViewModel/BasicInfoCellViewModel.swift
@@ -12,7 +12,7 @@ final class BasicInfoCellViewModel: CollectionCellViewModel {
     var cellClass: AnyClass = BasicInfoCell.self
     var indexPath: IndexPath?
     var cellTappedCallback: (() -> Void)?
-    var height: CGFloat = DesignSystem.sizeRegular
+    var height: CGFloat
     
     let title: String
     let subtitle1: String?
@@ -26,6 +26,7 @@ final class BasicInfoCellViewModel: CollectionCellViewModel {
         subtitle2: String? = nil,
         caption: String? = nil,
         icon: UIImage? = nil,
+        size: CellSize,
         cellTappedCallback: (() -> Void)? = nil
     ) {
         self.title = title
@@ -33,6 +34,7 @@ final class BasicInfoCellViewModel: CollectionCellViewModel {
         self.subtitle2 = subtitle2
         self.caption = caption
         self.icon = icon
+        self.height = size.height
         self.cellTappedCallback = cellTappedCallback
     }
 }

--- a/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsSection.swift
+++ b/GameDex/MyCollection/MyCollectionByPlatform/MyCollectionByPlatformsSection.swift
@@ -22,6 +22,7 @@ final class MyCollectionByPlatformsSection: Section {
                 subtitle2: item.game.formattedReleaseDate,
                 caption: item.game.imageUrl,
                 icon: item.isPhysical ? GameFormat.physical.image : GameFormat.digital.image,
+                size: .regular,
                 cellTappedCallback: {
                     let screenFactory = GameDetailsScreenFactory(
                         gameDetailsContext: .edit(savedGame: item),

--- a/GameDex/MyCollection/MyCollectionOverview/MyCollectionSection.swift
+++ b/GameDex/MyCollection/MyCollectionOverview/MyCollectionSection.swift
@@ -30,6 +30,7 @@ final class MyCollectionSection: Section {
                 title: platform.title,
                 subtitle1: "\(gameArray.count) \(text)",
                 caption: platform.imageUrl,
+                size: .small,
                 cellTappedCallback: {
                     let screenFactory = MyCollectionByPlatformsScreenFactory(
                         platform: platform,

--- a/GameDexTests/Common/CellsViewModel/BasicInfoCellViewModelTests.swift
+++ b/GameDexTests/Common/CellsViewModel/BasicInfoCellViewModelTests.swift
@@ -23,7 +23,8 @@ final class BasicInfoCellViewModelTests: XCTestCase {
             subtitle1: subtitle1,
             subtitle2: subtitle2,
             caption: captionName,
-            icon: icon
+            icon: icon,
+            size: .big
         )
         // Then
         XCTAssertEqual(cellVM.title, "Title")
@@ -32,5 +33,6 @@ final class BasicInfoCellViewModelTests: XCTestCase {
         XCTAssertEqual(cellVM.subtitle2, "Subtitle 2")
         XCTAssertEqual(cellVM.caption, "Caption Name")
         XCTAssertEqual(cellVM.reuseIdentifier, "\(cellVM.cellClass)")
+        XCTAssertEqual(cellVM.height, DesignSystem.sizeBig)
     }
 }


### PR DESCRIPTION
**What was the issue :** 
1. We used only one size for BasicInfoCell which was used in 4 different screens. It didn't make sense as there were more or less content in the cell depending on the screen.
2. When the game title was very long, the platform label was crushed in-between the game title and release date on MyCollectionByPlatform and SearchGameByTitle screens

**In more details :** 
1. We passed the CellSize in BasicInfoCellVM init with different size depending on needs
2. We set content hugging and compression resistance priorities to labels in BasicInfoCell to prevent the labels from getting crushed between one another


| SearchGame BEFORE light mode  | SearchGame BEFORE dark mode  | SearchGame AFTER light mode  | SearchGame AFTER dark mode  |
|---|---|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 04 19](https://github.com/RabiosStudio/GameDex/assets/117658161/6053232a-2247-47dc-b1a9-039bbbba0876)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 04 17](https://github.com/RabiosStudio/GameDex/assets/117658161/f578581c-2c90-45db-9cea-fb42f88661e1)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 03 28](https://github.com/RabiosStudio/GameDex/assets/117658161/19df4b0d-880f-4db4-a589-13edc5af5475)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 03 30](https://github.com/RabiosStudio/GameDex/assets/117658161/27a0d0a3-2788-4f31-a57a-f914487c2a20)  |


| SearchPlatform BEFORE light mode  | SearchPlatform BEFORE dark mode  | SearchPlatform AFTER light mode  | SearchPlatform AFTER dark mode  |
|---|---|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 04 03](https://github.com/RabiosStudio/GameDex/assets/117658161/b5d821ff-bc57-489f-b31c-2710230e41df)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 04 04](https://github.com/RabiosStudio/GameDex/assets/117658161/3fcee009-d608-4198-8f0a-232fa39c501b)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 03 09](https://github.com/RabiosStudio/GameDex/assets/117658161/58178c0d-46c3-41a3-8098-898c256bcaa4)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 03 07](https://github.com/RabiosStudio/GameDex/assets/117658161/357947e6-eab9-4453-89be-a524c5bab753)  |


| Collection BEFORE light mode  | Collection BEFORE dark mode  | Collection AFTER light mode  | Collection AFTER dark mode  |
|---|---|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 03 58](https://github.com/RabiosStudio/GameDex/assets/117658161/9dc52c6f-094d-43f3-a296-dbe85242e772)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 03 56](https://github.com/RabiosStudio/GameDex/assets/117658161/9039a960-6bbb-4cfb-9e6b-7b7c5982e641)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 02 59](https://github.com/RabiosStudio/GameDex/assets/117658161/dfb3efa1-0ab1-4194-84c5-5ce1bcb9b30d)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 11 03 01](https://github.com/RabiosStudio/GameDex/assets/117658161/46d39d78-bc3f-4509-8633-bdbe7d215668)  |


| Collection by platform BEFORE light mode  | Collection by platform BEFORE dark mode  | Collection by platform AFTER light mode  | Collection by platform AFTER dark mode  |
|---|---|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 10 59 03](https://github.com/RabiosStudio/GameDex/assets/117658161/e2d515d0-c62c-42ab-a272-5a505de0aba9)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 10 59 01](https://github.com/RabiosStudio/GameDex/assets/117658161/caf60bf8-bf72-4d8b-8b20-a21892bcc9b7)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 10 58 22](https://github.com/RabiosStudio/GameDex/assets/117658161/5807ab2d-14fb-48c0-9a98-8e9cfd4f987c)  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-06-14 at 10 58 31](https://github.com/RabiosStudio/GameDex/assets/117658161/37762d3c-00eb-4e55-b263-d2f394bfaca1)  |
